### PR TITLE
Feat: 로그인 회원가입 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "orum-market-front",
       "version": "0.0.0",
       "dependencies": {
+        "@clerk/clerk-react": "^4.28.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.18",
@@ -19,6 +20,7 @@
         "styled-components": "^6.1.1"
       },
       "devDependencies": {
+        "@types/node": "^20.9.4",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
@@ -247,6 +249,61 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-4.28.0.tgz",
+      "integrity": "sha512-zMFdiqqXkwAks1xmheUrAS6GODDdlpsCHA3VEnNVlSL0XH3bE4jWNr7lr0SJMmcaEsmZE/JQ+uNPJ4qEvEDGjA==",
+      "dependencies": {
+        "@clerk/shared": "1.1.0",
+        "@clerk/types": "3.58.0",
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@clerk/clerk-react/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+    },
+    "node_modules/@clerk/shared": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-1.1.0.tgz",
+      "integrity": "sha512-rxQ6bxAERZsf/dzCU35qt3gRp9+a035Vrre8j8tyT60dbP8PQhXUbeNu+oVqqjpHWeyoWWt6fZGLXbDTXdXx7g==",
+      "dependencies": {
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.1",
+        "swr": "2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-3.58.0.tgz",
+      "integrity": "sha512-fIsvEM3nYQwViOuYxNVcwEl0WkXW6AdYpSghNBKfOge1kriSSHP++T5rRMJBXy6asl2AEydVlUBKx9drAzqKoA==",
+      "dependencies": {
+        "csstype": "3.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@clerk/types/node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
@@ -1558,6 +1615,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
+      "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -3094,6 +3160,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/globals": {
       "version": "13.23.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
@@ -3735,6 +3806,14 @@
         "has-symbols": "^1.0.3",
         "reflect.getprototypeof": "^1.0.4",
         "set-function-name": "^2.0.1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -4993,6 +5072,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
+      "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -5181,6 +5271,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -5197,6 +5293,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@clerk/clerk-react": "^4.28.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.18",
@@ -21,6 +22,7 @@
     "styled-components": "^6.1.1"
   },
   "devDependencies": {
+    "@types/node": "^20.9.4",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,15 @@
 import { styled, alpha } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
-import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import InputBase from '@mui/material/InputBase';
 import MenuIcon from '@mui/icons-material/Menu';
 import SearchIcon from '@mui/icons-material/Search';
+
+import { SignedIn, SignedOut, UserButton } from '@clerk/clerk-react';
+import { Button, Container } from '@mui/material';
 import { Link } from 'react-router-dom';
-import { Avatar } from '@mui/material';
 
 const Search = styled('div')(({ theme }) => ({
   position: 'relative',
@@ -55,7 +56,7 @@ const StyledInputBase = styled(InputBase)(({ theme }) => ({
 
 export default function Header() {
   return (
-    <Box sx={{ flexGrow: 1 }}>
+    <Container maxWidth="sm">
       <AppBar position="fixed">
         <Toolbar>
           <IconButton
@@ -67,15 +68,16 @@ export default function Header() {
             <MenuIcon />
           </IconButton>
 
-          <Typography
-            variant="h6"
-            noWrap
-            component="div"
-            sx={{ flexGrow: 1, display: { xs: 'none', sm: 'block' } }}
-          >
-            ORUM
-          </Typography>
-
+          <Link to="/">
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              sx={{ flexGrow: 1, display: { xs: 'none', sm: 'block' } }}
+            >
+              ORUM
+            </Typography>
+          </Link>
           <Search>
             <SearchIconWrapper>
               <SearchIcon />
@@ -85,11 +87,29 @@ export default function Header() {
               inputProps={{ 'aria-label': 'search' }}
             />
           </Search>
-          <Link to="/user/:1">
-            <Avatar sx={{ width: 32, height: 32 }}>H</Avatar>
-          </Link>
+          <SignedIn>
+            <Link to="/user/1">
+              <Button variant="text" color="inherit">
+                대시보드
+              </Button>
+            </Link>
+            <UserButton afterSignOutUrl="/" />
+          </SignedIn>
+          <SignedOut>
+            <Link to="/sign-in/*">
+              <Button variant="text" color="inherit">
+                로그인
+              </Button>
+            </Link>
+            <Link to="sign-up/*">
+              <Button variant="text" color="inherit">
+                회원가입
+              </Button>
+            </Link>
+          </SignedOut>
         </Toolbar>
       </AppBar>
-    </Box>
+      <Toolbar />
+    </Container>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import ProductUpdate from './components/seller/ProductUpdate.tsx';
 import SellerInfo from './components/seller/SellerInfo.tsx';
 import SellerOrderList from './components/seller/SellerOrderList.tsx';
 import ProductManager from './components/seller/ProductManager.tsx';
+import { ClerkProvider, SignIn, SignUp } from '@clerk/clerk-react';
 
 const router = createBrowserRouter([
   {
@@ -28,6 +29,8 @@ const router = createBrowserRouter([
       { path: '/product', element: <ProductList /> },
       { path: '/product/:id', element: <ProductDetail /> },
       { path: '/cart', element: <MyCart /> },
+      { path: '/sign-in/*', element: <SignIn /> },
+      { path: '/sign-up/*', element: <SignUp /> },
     ],
   },
   {
@@ -72,6 +75,13 @@ const router = createBrowserRouter([
   },
 ]);
 
+if (!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY) {
+  throw new Error('Missing Publishable Key');
+}
+const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <RouterProvider router={router} />,
+  <ClerkProvider publishableKey={clerkPubKey} afterSignUpUrl="/">
+    <RouterProvider router={router} />
+  </ClerkProvider>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,11 @@
+import { CssBaseline } from '@mui/material';
+import { Box } from '@mui/system';
+
 export default function Home() {
   return (
-    <div>
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
       <h1>Orum Market</h1>
-    </div>
+    </Box>
   );
 }


### PR DESCRIPTION
- Clerk 을 이용한 회원가입, 로그인 구현

## 🧾 관련 이슈
close : #4 


## 🔎 구현한 내용
- Clerk을 활용한 이메일 회원가입, 로그인
- 구글, 깃헙 로그인
- 로그인 후 메인 페이지 이동
- 로그아웃 후 메인 페이지 이동


## 📸 스크린샷(선택사항)
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/9db923a0-c596-4ff5-824d-5e15e421daf8)
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/8681c227-7d70-4222-8198-e86a99002117)
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/736c3753-aeaa-4944-880c-8716438c5cae)



## 🙌 리뷰어에게
- 위 스크린 샷을 보시면 Clerk 에서 제공하는 기본 모달이 있습니다. 이를 어떻게 재사용할지 고민이 필요해보입니다.
- 유저 대시보드 헤더에는 아바타를 추가하지 않았습니다. 해당 영역 작업하시는 분께서는 헤더(/componenets/Header.tsx)의 <UserButton /> 부분을 복사해서 사용하시면 됩니다.
- 헤더의 버튼과 영역에 관한 부분은 추후에 UI/UX 파트에서 수정합니다.




