### PR TITLE
Feat: 관리자 페이지(대시보드) 기본 라우팅 구현

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,18 +1,22 @@
 export const DASHBOARD_MENU = {
   buyer: [
     {
+      id: 1,
       title: '구매자 대시보드',
       url: '/user/:id',
     },
     {
+      id: 2,
       title: '주문 내역',
       url: '/user/:id/buyer-orderlist',
     },
     {
+      id: 3,
       title: '찜한 상품',
       url: '/user/:id/buyer-favorite',
     },
     {
+      id: 4,
       title: '최근 본 상품',
       url: '/user/:id/buyer-orderlist',
     },
@@ -20,14 +24,17 @@ export const DASHBOARD_MENU = {
 
   seller: [
     {
+      id: 1,
       title: '판매자 대시보드',
       url: '/user/:id/seller-orderlist',
     },
     {
+      id: 2,
       title: '판매자 정보',
       url: '/user/:id/seller-info',
     },
     {
+      id: 3,
       title: '상품 관리',
       url: '/user/:id/product-manager',
     },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,35 @@
+export const DASHBOARD_MENU = {
+  buyer: [
+    {
+      title: '구매자 대시보드',
+      url: '/user/:id',
+    },
+    {
+      title: '주문 내역',
+      url: '/user/:id/buyer-orderlist',
+    },
+    {
+      title: '찜한 상품',
+      url: '/user/:id/buyer-favorite',
+    },
+    {
+      title: '최근 본 상품',
+      url: '/user/:id/buyer-orderlist',
+    },
+  ],
+
+  seller: [
+    {
+      title: '판매자 대시보드',
+      url: '/user/:id/seller-orderlist',
+    },
+    {
+      title: '판매자 정보',
+      url: '/user/:id/seller-info',
+    },
+    {
+      title: '상품 관리',
+      url: '/user/:id/product-manager',
+    },
+  ],
+};

--- a/src/pages/user/Dashboard.tsx
+++ b/src/pages/user/Dashboard.tsx
@@ -16,6 +16,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { Link, Outlet } from 'react-router-dom';
+import { DASHBOARD_MENU } from '../../constants';
 
 const drawerWidth = 240;
 
@@ -36,28 +37,30 @@ export default function Dashboard(props: Props) {
       <Toolbar />
       <Divider />
       <List>
-        {['구매자 대시보드', '주문내역', '찜한 상품', '최근 본 상품'].map(
-          (text, index) => (
-            <ListItem key={text} disablePadding>
-              <ListItemButton>
-                <ListItemIcon>
-                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} />
-              </ListItemButton>
-            </ListItem>
-          ),
-        )}
-      </List>
-      <Divider />
-      <List>
-        {['판매자 대시보드', '판매자 정보', '상품 관리'].map((text, index) => (
-          <ListItem key={text} disablePadding>
+        {DASHBOARD_MENU.buyer.map((items, index) => (
+          <ListItem key={index} disablePadding>
             <ListItemButton>
               <ListItemIcon>
                 {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
               </ListItemIcon>
-              <ListItemText primary={text} />
+              <Link to={items.url}>
+                <ListItemText primary={items.title} />
+              </Link>
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+      <List>
+        {DASHBOARD_MENU.seller.map((items, index) => (
+          <ListItem key={index} disablePadding>
+            <ListItemButton>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <Link to={items.url}>
+                <ListItemText primary={items.title} />
+              </Link>
             </ListItemButton>
           </ListItem>
         ))}

--- a/src/pages/user/Dashboard.tsx
+++ b/src/pages/user/Dashboard.tsx
@@ -37,11 +37,11 @@ export default function Dashboard(props: Props) {
       <Toolbar />
       <Divider />
       <List>
-        {DASHBOARD_MENU.buyer.map((items, index) => (
-          <ListItem key={index} disablePadding>
+        {DASHBOARD_MENU.buyer.map((items) => (
+          <ListItem key={items.id} disablePadding>
             <ListItemButton>
               <ListItemIcon>
-                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
               </ListItemIcon>
               <Link to={items.url}>
                 <ListItemText primary={items.title} />
@@ -52,11 +52,11 @@ export default function Dashboard(props: Props) {
       </List>
       <Divider />
       <List>
-        {DASHBOARD_MENU.seller.map((items, index) => (
-          <ListItem key={index} disablePadding>
+        {DASHBOARD_MENU.seller.map((items) => (
+          <ListItem key={items.id} disablePadding>
             <ListItemButton>
               <ListItemIcon>
-                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
               </ListItemIcon>
               <Link to={items.url}>
                 <ListItemText primary={items.title} />


### PR DESCRIPTION
## 🧾 관련 이슈
close : #3 


## 🔎 구현한 내용
- 대시보드 메뉴명 및 URL 상수 선언
- 관리자 페이지 메뉴 라우팅 연결


## 📸 스크린샷(선택사항)
<img width="600" alt="대시보드 라우팅" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/c19c13e5-a01e-4d0d-9bec-6532cf19ceeb">


## 🙌 리뷰어에게
- 대시보드 메뉴의 경우 변경이 거의 없기 때문에 상수로 관리하고자 데이터를 분류했습니다.
- 사이드바 디자인의 경우 추후 UX/UI 작업 때 수정합니다.

