### PR TITLE
Feat: 메인 페이지 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,4 +26,5 @@ export const api = {
   checkEmail: (email: string) =>
     axiosInstance.get('/users/email', { params: { email } }),
   signIn: (credentials: any) => axiosInstance.post('/users/login', credentials),
+  getProductList: () => axiosInstance.get('/products'),
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -27,4 +27,6 @@ export const api = {
     axiosInstance.get('/users/email', { params: { email } }),
   signIn: (credentials: any) => axiosInstance.post('/users/login', credentials),
   getProductList: () => axiosInstance.get('/products'),
+  searchProducts: (keyword: string) =>
+    axiosInstance.get('/products', { params: { keyword } }),
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,13 +11,15 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import { Badge, Button, Container } from '@mui/material';
+import { Badge, Box, Button, Container } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUserStore } from '../lib/store';
 import { useState } from 'react';
 import { Logout } from '@mui/icons-material';
 import { UserStore } from '../lib/store';
+
+const categories = ['tops', 'bottoms', 'backpacks', 'shoes', 'gear'];
 
 export default function Header() {
   const [openLogoutDialog, setOpenLogoutDialog] = useState(false);
@@ -85,6 +87,19 @@ export default function Header() {
     );
   }
 
+  const renderCategoryLinks = () => {
+    return categories.map((category) => (
+      <Button
+        key={category}
+        component={Link}
+        to={`/category/${category}`}
+        color="inherit"
+      >
+        {category.charAt(0).toUpperCase() + category.slice(1)}
+      </Button>
+    ));
+  };
+
   return (
     <Container maxWidth="sm">
       <AppBar position="fixed">
@@ -108,6 +123,9 @@ export default function Header() {
               ORUM
             </Typography>
           </Link>
+
+          <Box sx={{ display: 'flex' }}>{renderCategoryLinks()}</Box>
+
           <Search>
             <SearchIconWrapper>
               <SearchIcon />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,15 +15,22 @@ import { Badge, Box, Button, Container } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUserStore } from '../lib/store';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Logout } from '@mui/icons-material';
-import { UserStore } from '../lib/store';
 
 const categories = ['tops', 'bottoms', 'backpacks', 'shoes', 'gear'];
 
 export default function Header() {
   const [openLogoutDialog, setOpenLogoutDialog] = useState(false);
-  const { isLoggedIn, logOut }: UserStore = useUserStore();
+  const { isLoggedIn, logOut } = useUserStore();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    let queryParam = `?query=${searchQuery}`;
+    navigate(`/search${queryParam}`);
+    setSearchQuery('');
+  };
 
   const navigate = useNavigate();
 
@@ -37,9 +44,9 @@ export default function Header() {
 
   const handleLogout = () => {
     logOut();
+    localStorage.removeItem('token');
     alert('로그아웃 되었습니다. 다음에 또 만나요!');
     setOpenLogoutDialog(false);
-    localStorage.removeItem('token');
     navigate('/');
   };
 
@@ -125,16 +132,22 @@ export default function Header() {
           </Link>
 
           <Box sx={{ display: 'flex' }}>{renderCategoryLinks()}</Box>
-
-          <Search>
-            <SearchIconWrapper>
-              <SearchIcon />
-            </SearchIconWrapper>
-            <StyledInputBase
-              placeholder="Search…"
-              inputProps={{ 'aria-label': 'search' }}
-            />
-          </Search>
+          <form onSubmit={handleSearch}>
+            <Search>
+              <SearchIconWrapper>
+                <SearchIcon />
+              </SearchIconWrapper>
+              <StyledInputBase
+                placeholder="검색해볼까"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                inputProps={{ 'aria-label': 'search' }}
+              />
+              <Button type="submit" color="inherit" variant="outlined">
+                검색
+              </Button>
+            </Search>
+          </form>
           {isLoggedIn && isLoggedInUserButton()}
           {!isLoggedIn && notLoggedInUserButton()}
         </Toolbar>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,7 @@ import ProductManager from './components/seller/ProductManager.tsx';
 import SignInPage from './pages/user/SignIn.tsx';
 import SignUpPage from './pages/user/SignUp.tsx';
 import { CategoryList } from './pages/product/CategoryList.tsx';
+import { SearchResults } from './pages/product/SearchResult.tsx';
 
 const router = createBrowserRouter([
   {
@@ -32,6 +33,7 @@ const router = createBrowserRouter([
       { path: '/product', element: <ProductList /> },
       { path: '/product/:id', element: <ProductDetail /> },
       { path: '/cart', element: <MyCart /> },
+      { path: '/search', element: <SearchResults /> },
       { path: '/sign-in', element: <SignInPage /> },
       { path: '/sign-up', element: <SignUpPage /> },
     ],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,7 @@ import SellerOrderList from './components/seller/SellerOrderList.tsx';
 import ProductManager from './components/seller/ProductManager.tsx';
 import SignInPage from './pages/user/SignIn.tsx';
 import SignUpPage from './pages/user/SignUp.tsx';
+import { CategoryList } from './pages/product/CategoryList.tsx';
 
 const router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
     errorElement: <NotFound />,
     children: [
       { index: true, path: '/', element: <Home /> },
+      { path: '/category/:category', element: <CategoryList /> },
       { path: '/product', element: <ProductList /> },
       { path: '/product/:id', element: <ProductDetail /> },
       { path: '/cart', element: <MyCart /> },

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,45 +1,12 @@
 import { CssBaseline } from '@mui/material';
 import { Box } from '@mui/system';
-
-import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import axios from 'axios';
+import ProductList from './product/ProductList';
 
 export default function Home() {
-  const [data, setData] = useState<{ item: ProductItem | undefined }>();
-  axios
-    .get('https://localhost:443/api/products/')
-    .then(function (response) {
-      // 성공 핸들링
-      console.log(response);
-    })
-
-    .catch(function (error) {
-      // 에러 핸들링
-      console.log(error);
-    })
-    .finally(function () {
-      // 항상 실행되는 영역
-    });
-  //axios 받아오기
-
-  const { productId } = useParams(); //상품id
-
-  interface ProductItem {
-    //데이터 받아올때 쓰려고 만듦
-    _id: number;
-    name: string;
-    price: number;
-  }
-
-  interface productResponce {
-    ok: number;
-    item: ProductItem[];
-  }
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
-      <h1>Orum Market</h1>
+      <ProductList />
     </Box>
   );
 }

--- a/src/pages/product/CategoryList.tsx
+++ b/src/pages/product/CategoryList.tsx
@@ -1,51 +1,94 @@
-import { Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import {
+  Box,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+} from '@mui/material';
 import { useParams } from 'react-router-dom';
 import { IProduct } from '../../type';
 import { useEffect, useState } from 'react';
 import { api } from '../../api/api';
+import ProductCard from './ProductCard';
 
 export const CategoryList = () => {
   const { category } = useParams<{ category: string }>();
   const [products, setProducts] = useState<IProduct[]>([]);
+  const [sortOrder, setSortOrder] = useState('최신순');
 
   useEffect(() => {
     const fetchProducts = async () => {
       const response = await api.getProductList();
-      const filteredProducts = response.data.item.filter(
+      let filteredProducts = response.data.item.filter(
         (product: IProduct) => product.extra.category[1] === category,
       );
+
+      switch (sortOrder) {
+        case '최신순':
+          filteredProducts.sort(
+            (a: IProduct, b: IProduct) =>
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+          );
+          break;
+        case '오래된순':
+          filteredProducts.sort(
+            (a: IProduct, b: IProduct) =>
+              new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+          );
+          break;
+        case '가-하':
+          filteredProducts.sort(
+            (a: IProduct, b: IProduct) => a.price - b.price,
+          );
+          break;
+        case '하-가':
+          filteredProducts.sort(
+            (a: IProduct, b: IProduct) => b.price - a.price,
+          );
+          break;
+        default:
+          break;
+      }
+
       setProducts(filteredProducts);
     };
+
     fetchProducts();
-  }, [category]);
+  }, [category, sortOrder]);
 
   return (
-    <div>
-      <h1>{category}</h1>
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 2,
+        }}
+      >
+        <h1>{category}</h1>
+        <FormControl>
+          <InputLabel id="sort-label">정렬</InputLabel>
+          <Select
+            labelId="sort-label"
+            id="sort-select"
+            value={sortOrder}
+            label="정렬"
+            onChange={(e) => setSortOrder(e.target.value)}
+          >
+            <MenuItem value="최신순">최신순</MenuItem>
+            <MenuItem value="오래된순">오래된순</MenuItem>
+            <MenuItem value="가-하">가격: 낮은 순</MenuItem>
+            <MenuItem value="하-가">가격: 높은 순</MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
       <Grid container spacing={2}>
         {products.map((product) => (
-          <Grid item xs={12} sm={6} md={4} key={product._id}>
-            <Card>
-              <CardMedia
-                component="img"
-                height="140"
-                image={product.mainImages[0]}
-                alt={product.name}
-              />
-              <CardContent>
-                <Typography gutterBottom variant="h5" component="div">
-                  {product.name}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Price: {product.price}원
-                  <br />
-                  Shipping Fees: {product.shippingFees}원
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
+          <ProductCard key={product._id} product={product} />
         ))}
       </Grid>
-    </div>
+    </>
   );
 };

--- a/src/pages/product/CategoryList.tsx
+++ b/src/pages/product/CategoryList.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import { useParams } from 'react-router-dom';
+import { IProduct } from '../../type';
+import { useEffect, useState } from 'react';
+import { api } from '../../api/api';
+
+export const CategoryList = () => {
+  const { category } = useParams<{ category: string }>();
+  const [products, setProducts] = useState<IProduct[]>([]);
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+      const response = await api.getProductList();
+      const filteredProducts = response.data.item.filter(
+        (product: IProduct) => product.extra.category[1] === category,
+      );
+      setProducts(filteredProducts);
+    };
+    fetchProducts();
+  }, [category]);
+
+  return (
+    <div>
+      <h1>{category}</h1>
+      <Grid container spacing={2}>
+        {products.map((product) => (
+          <Grid item xs={12} sm={6} md={4} key={product._id}>
+            <Card>
+              <CardMedia
+                component="img"
+                height="140"
+                image={product.mainImages[0]}
+                alt={product.name}
+              />
+              <CardContent>
+                <Typography gutterBottom variant="h5" component="div">
+                  {product.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Price: {product.price}원
+                  <br />
+                  Shipping Fees: {product.shippingFees}원
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </div>
+  );
+};

--- a/src/pages/product/ProductCard.tsx
+++ b/src/pages/product/ProductCard.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import { IProduct } from '../../type';
+
+interface ProductCardProps {
+  product: IProduct;
+}
+
+export default function ProductCard({ product }: ProductCardProps) {
+  return (
+    <Grid item xs={12} sm={6} md={4} lg={3} xl={2}>
+      <Card>
+        <CardMedia
+          component="img"
+          height="140"
+          image={product.mainImages[0]}
+          alt={product.name}
+        />
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="div">
+            {product.name}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Price: {product.price}원
+            <br />
+            Shipping Fees: {product.shippingFees}원
+          </Typography>
+        </CardContent>
+      </Card>
+    </Grid>
+  );
+}

--- a/src/pages/product/ProductList.tsx
+++ b/src/pages/product/ProductList.tsx
@@ -1,7 +1,47 @@
+import { useEffect, useState } from 'react';
+import { IProduct } from '../../type';
+import { api } from '../../api/api';
+import { Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+
 export default function ProductList() {
+  const [products, setProducts] = useState<IProduct[]>([]);
+
+  useEffect(() => {
+    fetchProducts();
+  }, []);
+
+  const fetchProducts = async () => {
+    const response = await api.getProductList();
+    setProducts(response.data.item);
+  };
+
   return (
     <main>
       <h1>제품 전체 목록 페이지</h1>
+      <Grid container spacing={2}>
+        {products.map((product) => (
+          <Grid item xs={12} sm={6} md={4} key={product._id}>
+            <Card>
+              <CardMedia
+                component="img"
+                height="140"
+                image={product.mainImages[0]}
+                alt={product.name}
+              />
+              <CardContent>
+                <Typography gutterBottom variant="h5" component="div">
+                  {product.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Price: {product.price}원
+                  <br />
+                  Shipping Fees: {product.shippingFees}원
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
     </main>
   );
 }

--- a/src/pages/product/ProductList.tsx
+++ b/src/pages/product/ProductList.tsx
@@ -1,7 +1,18 @@
 import { useEffect, useState } from 'react';
-import { IProduct } from '../../type';
+import { ICategoryPreview, IProduct } from '../../type';
 import { api } from '../../api/api';
-import { Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import {
+  Button,
+  Box,
+  Card,
+  CardContent,
+  CardMedia,
+  Grid,
+  Typography,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+
+const categories = ['tops', 'bottoms', 'backpacks', 'shoes', 'gear'];
 
 export default function ProductList() {
   const [products, setProducts] = useState<IProduct[]>([]);
@@ -18,9 +29,38 @@ export default function ProductList() {
   return (
     <main>
       <h1>제품 전체 목록 페이지</h1>
+      {categories.map((category) => (
+        <CategoryPreview
+          key={category}
+          category={category}
+          products={products.filter(
+            (product) => product.extra.category[1] === category,
+          )}
+        />
+      ))}
+    </main>
+  );
+}
+
+const CategoryPreview = ({ category, products }: ICategoryPreview) => {
+  return (
+    <Box sx={{ marginBottom: 4 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 2,
+        }}
+      >
+        <Typography variant="h5">{category}</Typography>
+        <Button component={Link} to={`/category/${category}`}>
+          더보기
+        </Button>
+      </Box>
       <Grid container spacing={2}>
-        {products.map((product) => (
-          <Grid item xs={12} sm={6} md={4} key={product._id}>
+        {products.slice(0, 5).map((product) => (
+          <Grid item xs={12} sm={6} md={4} lg={3} xl={2} key={product._id}>
             <Card>
               <CardMedia
                 component="img"
@@ -42,6 +82,6 @@ export default function ProductList() {
           </Grid>
         ))}
       </Grid>
-    </main>
+    </Box>
   );
-}
+};

--- a/src/pages/product/ProductList.tsx
+++ b/src/pages/product/ProductList.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useState } from 'react';
 import { ICategoryPreview, IProduct } from '../../type';
 import { api } from '../../api/api';
-import {
-  Button,
-  Box,
-  Card,
-  CardContent,
-  CardMedia,
-  Grid,
-  Typography,
-} from '@mui/material';
+import { Button, Box, Grid, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
+import ProductCard from './ProductCard';
 
 const categories = ['tops', 'bottoms', 'backpacks', 'shoes', 'gear'];
 
@@ -60,26 +53,7 @@ const CategoryPreview = ({ category, products }: ICategoryPreview) => {
       </Box>
       <Grid container spacing={2}>
         {products.slice(0, 5).map((product) => (
-          <Grid item xs={12} sm={6} md={4} lg={3} xl={2} key={product._id}>
-            <Card>
-              <CardMedia
-                component="img"
-                height="140"
-                image={product.mainImages[0]}
-                alt={product.name}
-              />
-              <CardContent>
-                <Typography gutterBottom variant="h5" component="div">
-                  {product.name}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Price: {product.price}원
-                  <br />
-                  Shipping Fees: {product.shippingFees}원
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
+          <ProductCard key={product._id} product={product} />
         ))}
       </Grid>
     </Box>

--- a/src/pages/product/SearchResult.tsx
+++ b/src/pages/product/SearchResult.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { IProduct } from '../../type';
+import { api } from '../../api/api';
+import ProductCard from './ProductCard';
+import { Grid } from '@mui/material';
+
+export function SearchResults() {
+  const [searchParams] = useSearchParams();
+  const [results, setResults] = useState<IProduct[]>([]);
+
+  useEffect(() => {
+    const fetchSearchResults = async () => {
+      const query = searchParams.get('query');
+      if (query) {
+        const response = await api.searchProducts(query);
+        setResults(response.data.item);
+        console.log(response.data.item);
+      }
+    };
+
+    fetchSearchResults();
+  }, [searchParams]);
+
+  return (
+    <>
+      <h1>Search Results</h1>
+      {/* // 검색어를 표시해주자. 검색 상품 수도 표시해주자 */}
+      <h3>
+        '{searchParams.get('query')}' 검색 결과 {results.length}개의 상품이
+        있습니다.
+      </h3>
+      <Grid container spacing={2}>
+        {results &&
+          Array.isArray(results) &&
+          results.map((product) => (
+            <ProductCard key={product._id} product={product} />
+          ))}
+        {results.length === 0 && <h2>검색 결과가 없습니다.</h2>}
+      </Grid>
+    </>
+  );
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,0 +1,19 @@
+export interface IProduct {
+  _id: number;
+  name: string;
+  price: number;
+  shippingFees: number;
+  show: boolean;
+  active: boolean;
+  mainImages: string[];
+  extra: {
+    isNew: boolean;
+    isBest: boolean;
+    category: string[];
+    quantity: number;
+    buyQuantity: number;
+    order: number;
+  };
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -17,3 +17,8 @@ export interface IProduct {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface ICategoryPreview {
+  category: string;
+  products: IProduct[];
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #13 


## 🔎 구현한 내용
- 메인, 카테고리, 검색 페이지 구현
- 필터, 정렬, 검색 기능 구현



## 📸 스크린샷(선택사항)
메인 페이지
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/35e205b2-61cc-4b6c-bc22-05e0131a17a4)

카테고리 페이지
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/5b71bf54-fd1f-4c72-8312-1b3826cce709)

검색 결과 페이지
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/9d7cce59-aa0e-4975-a301-eeb323c25203)




## 🙌 리뷰어에게
- 헤더에 많은 내용이 들어가서 반응형에 따른 UI를 어떻게 구성할지 고민이 필요해 보입니다.


