### PR TITLE
Feat: 헤더 카트 기능

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import { Badge, Box, Button, Container } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import { Link, useNavigate } from 'react-router-dom';
 import { useUserStore } from '../lib/store';
 import React, { useState } from 'react';
@@ -64,6 +65,13 @@ export default function Header() {
             <NotificationsIcon />
           </Badge>
         </IconButton>
+        <Link to="/cart" style={{ textDecoration: 'none', color: 'inherit' }}>
+          <IconButton color="inherit">
+            <Badge badgeContent={4} color="error">
+              <ShoppingCartIcon />
+            </Badge>
+          </IconButton>
+        </Link>
         {/* 로그아웃 버튼은 아바타 클릭 후 생성되는 모달 안으로 이동 시킬 것 */}
         <Button onClick={handleLogoutDialogOpen} variant="text" color="inherit">
           로그아웃

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,7 +15,7 @@ import { Badge, Box, Button, Container } from '@mui/material';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import { Link, useNavigate } from 'react-router-dom';
-import { useUserStore } from '../lib/store';
+import { useCart, useUserStore } from '../lib/store';
 import React, { useState } from 'react';
 import { Logout } from '@mui/icons-material';
 
@@ -51,6 +51,9 @@ export default function Header() {
     navigate('/');
   };
 
+  const { items: cartItems } = useCart();
+  const cartItemsCount = cartItems.length;
+
   function isLoggedInUserButton() {
     return (
       <>
@@ -67,7 +70,7 @@ export default function Header() {
         </IconButton>
         <Link to="/cart" style={{ textDecoration: 'none', color: 'inherit' }}>
           <IconButton color="inherit">
-            <Badge badgeContent={4} color="error">
+            <Badge badgeContent={cartItemsCount} color="error">
               <ShoppingCartIcon />
             </Badge>
           </IconButton>

--- a/src/hooks/useAddToCart.ts
+++ b/src/hooks/useAddToCart.ts
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router-dom';
+import { useCartStore, useUserStore } from '../lib/store';
+import { ICartStore, IProduct, IUserStore } from '../type';
+
+// 장바구니에 상품 추가하는 커스텀 훅
+export const useAddToCart = () => {
+  const navigate = useNavigate();
+  const { isLoggedIn } = useUserStore() as IUserStore;
+  const { items, addToCart } = useCartStore() as ICartStore;
+
+  const handleAddToCart = (product: IProduct) => {
+    if (!isLoggedIn) {
+      const confirmLogin = window.confirm(
+        '로그인이 필요합니다. 로그인 페이지로 이동하시겠습니까?',
+      );
+      if (confirmLogin) {
+        navigate('/sign-in');
+      }
+      return;
+    }
+
+    const productAlreadyInCart = items.some((item) => item._id === product._id);
+    if (productAlreadyInCart) {
+      alert('이미 장바구니에 있는 상품입니다.');
+      return;
+    }
+
+    addToCart({ ...product, quantity: 1 });
+    const confirmAddToCart = window.confirm(
+      '장바구니에 추가되었습니다. 장바구니로 이동하시겠습니까?',
+    );
+    if (confirmAddToCart) {
+      navigate('/cart');
+    }
+  };
+
+  return handleAddToCart;
+};

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -41,3 +41,8 @@ export const useCartStore = create(
     },
   ),
 );
+
+export function useCart() {
+  const cartStore = useCartStore() as ICartStore;
+  return cartStore;
+}

--- a/src/pages/product/ProductCard.tsx
+++ b/src/pages/product/ProductCard.tsx
@@ -1,23 +1,40 @@
-import { Card, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import {
+  Button,
+  Card,
+  CardActionArea,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Grid,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import { IProduct } from '../../type';
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { useAddToCart } from '../../hooks/useAddToCart';
 
 interface ProductCardProps {
   product: IProduct;
 }
 
 export default function ProductCard({ product }: ProductCardProps) {
+  const handleAddToCart = useAddToCart();
+
   return (
     <Grid item xs={12} sm={6} md={4} lg={3} xl={2}>
       <Card>
-        <Link to={`/product/${product._id}`}>
-          <CardMedia
-            component="img"
-            height="140"
-            image={product.mainImages[0]}
-            alt={product.name}
-          />
-        </Link>
+        <Tooltip title="상품 페이지로 이동하기" arrow>
+          <CardActionArea component={Link} to={`/product/${product._id}`}>
+            <CustomCardMedia
+              component="img"
+              height="140"
+              image={product.mainImages[0]}
+              alt={product.name}
+            />
+          </CardActionArea>
+        </Tooltip>
         <CardContent>
           <Link
             to={`/product/${product._id}`}
@@ -33,7 +50,23 @@ export default function ProductCard({ product }: ProductCardProps) {
             Shipping Fees: {product.shippingFees}원
           </Typography>
         </CardContent>
+        <CardActions>
+          <Button
+            startIcon={<ShoppingCartIcon />}
+            onClick={() => handleAddToCart(product)}
+          >
+            장바구니
+          </Button>
+        </CardActions>
       </Card>
     </Grid>
   );
 }
+
+const CustomCardMedia = styled(CardMedia)`
+  transition: transform 0.3s ease-in-out;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+`;

--- a/src/pages/user/SignIn.tsx
+++ b/src/pages/user/SignIn.tsx
@@ -12,11 +12,12 @@ import {
 } from '@mui/material';
 import { Link, useNavigate } from 'react-router-dom';
 import { validateEmail, validatePassword } from '../../lib/validation';
+import { IUserStore } from '../../type';
 
 export default function SignInPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { logIn } = useUserStore();
+  const { logIn } = useUserStore() as IUserStore;
   const [showPassword, setShowPassword] = useState(false);
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');


### PR DESCRIPTION
## 🧾 관련 이슈
close : #20 


## 🔎 구현한 내용
- 상품 상세페이지에서 장바구니에 등록
- 장바구니 목록 하나씩 제거
- 장바구니 목록 전체 제거
- 장바구니에 들어있는 상품 갯수 만큼 헤더의 장바구니 아이콘에 뱃지로 표시
- 로그아웃 후 재로그인 시에도 장바구니 목록 유지
- 모든 상품은 1개라는 전제하에 똑같은 상품을 장바구니에 다시 담지 않도록 설정


## 📸 스크린샷(선택사항)
이미 장바구니에 해당 상품이 있을 경우
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/9da14504-931a-4cc0-b2c0-5110cfd4c9c3)

장바구니에 추가
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/905e9caf-898d-4104-9293-95b40452a521)

장바구니 페이지
![image](https://github.com/PhoenixFE/orum-market-front/assets/3222504/a6f8d0c9-a5f5-4e2a-b220-a3ee4a777ecf)




## 🙌 리뷰어에게
- 사용자별로 장바구니를 다르게 구현해야 함
- 관련 로직은 백엔드로 DB와 연결해야 하나, 아직 장바구니 관련 로직이 없어서 강사님께 문의해야 함
- 장바구니 목록을 결제하는 로직은 결제 관련 기능 구현하며 추가할 예정


