### PR TITLE
Fix: userId 로컬스토리지 사용

### DIFF
--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -28,7 +28,7 @@ export interface IBuyerInfo {
 }
 
 export default function BuyerInfo() {
-  const { id } = useParams();
+  const userId = localStorage.getItem('_id');
   const [buyerInfoData, setBuyerInfoData] = useState<IBuyerInfo>({
     _id: 0,
     email: '',
@@ -53,16 +53,21 @@ export default function BuyerInfo() {
   const handleUpdateUserInfo = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      await api.updateUserInfo(id, buyerInfoData);
+      await api.updateUserInfo(userId, buyerInfoData);
     } catch (error) {
       console.log(error);
     }
   };
 
   useEffect(() => {
+    if (!userId) {
+      console.log('ID가 유효하지 않습니다.');
+      return;
+    }
+
     const getBuyerInfo = async () => {
       try {
-        const response = await api.getUserInfo(id);
+        const response = await api.getUserInfo(userId);
         setBuyerInfoData({
           ...buyerInfoData,
           _id: response.data.item._id,
@@ -74,6 +79,7 @@ export default function BuyerInfo() {
         console.log(error);
       }
     };
+
     getBuyerInfo();
   }, []);
 


### PR DESCRIPTION
## 🧾 관련 이슈
close : 


## 🔎 구현한 내용
내 정보 수정에서 유저 id를 useParams로 사용하고 있던 부분을
로컬 스토리지에 저장한 값으로 변경


## 📸 스크린샷(선택사항)




## 🙌 리뷰어에게




