### PR TITLE
Feat: 구매자 주문내역 테이블 작업

### DIFF
--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import {
   Container,

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -76,6 +76,7 @@ export default function BuyerOrdeList() {
               <TableCell align="center">이미지</TableCell>
               <TableCell align="center">상품명</TableCell>
               <TableCell align="center">수량</TableCell>
+              <TableCell align="center">상품가격</TableCell>
               <TableCell align="center">주문처리상태</TableCell>
               <TableCell align="center">별점평가</TableCell>
             </TableRow>
@@ -91,12 +92,24 @@ export default function BuyerOrdeList() {
                 <TableCell align="center">
                   {rows.products[0].quantity}
                 </TableCell>
+                <TableCell align="center">{rows.products[0].price}</TableCell>
                 <TableCell align="center">{rows.state}</TableCell>
                 <TableCell align="center">
                   <Button type="button">별점등록</Button>
                 </TableCell>
               </TableRow>
             ))}
+            <TableRow>
+              <TableCell align="right" colSpan={7}>
+                총 가격{' '}
+                {dummUserOderList[0].cost.products +
+                  ' + ' +
+                  dummUserOderList[0].cost.shippingFees +
+                  ' = ' +
+                  dummUserOderList[0].cost.total +
+                  '원'}
+              </TableCell>
+            </TableRow>
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -9,29 +9,6 @@ import {
   Button,
 } from '@mui/material';
 
-export interface IExtraCategory {
-  [index: number]: string;
-}
-
-export interface IItems {
-  perchased_id: number;
-  seller_id: number;
-  item_id: number;
-  price: number;
-  shippingFees: number;
-  name: string;
-  mainImages: string;
-  quantity: number;
-  perchasedAt: string;
-  extra: {
-    category: IExtraCategory[];
-  };
-}
-
-export interface Iperchased {
-  item: IItems[];
-}
-
 const dummUserOderList = [
   {
     _id: 1,

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -1,3 +1,128 @@
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Paper,
+  Button,
+} from '@mui/material';
+
+export interface IExtraCategory {
+  [index: number]: string;
+}
+
+export interface IItems {
+  perchased_id: number;
+  seller_id: number;
+  item_id: number;
+  price: number;
+  shippingFees: number;
+  name: string;
+  mainImages: string;
+  quantity: number;
+  perchasedAt: string;
+  extra: {
+    category: IExtraCategory[];
+  };
+}
+
+export interface Iperchased {
+  item: IItems[];
+}
+
+const dummUserOderList = [
+  {
+    _id: 1,
+    user_id: 1,
+    state: '0S010',
+    products: [
+      {
+        _id: 1,
+        name: '네파 푸퍼',
+        images: 'imageUrl',
+        quantity: 1,
+        price: 12000,
+      },
+    ],
+    cost: {
+      products: 12000,
+      shippingFees: 2500,
+      total: 14500,
+    },
+    address: {
+      name: '우리집',
+      value: '서울시 강남구 어디동',
+    },
+    createAt: '2023-11-29',
+    updateAt: '2023-11-29',
+  },
+  {
+    _id: 2,
+    user_id: 1,
+    state: '0S010',
+    products: [
+      {
+        _id: 2,
+        name: '등산용 백팩',
+        images: 'imageUrl',
+        quantity: 1,
+        price: 24000,
+      },
+    ],
+    cost: {
+      products: 24000,
+      shippingFees: 3000,
+      total: 27000,
+    },
+    address: {
+      name: '우리집',
+      value: '서울시 강남구 어디동',
+    },
+    createAt: '2023-11-29',
+    updateAt: '2023-11-29',
+  },
+];
+
 export default function BuyerOrdeList() {
-  return <>BuyerOrderList</>;
+  return (
+    <>
+      <TableContainer component={Paper}>
+        <Table aria-label="구매내역">
+          <TableHead>
+            <TableRow>
+              <TableCell align="center">
+                주문일자
+                <br /> (주문번호)
+              </TableCell>
+              <TableCell align="center">이미지</TableCell>
+              <TableCell align="center">상품명</TableCell>
+              <TableCell align="center">수량</TableCell>
+              <TableCell align="center">주문처리상태</TableCell>
+              <TableCell align="center">별점평가</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {dummUserOderList.map((rows) => (
+              <TableRow key={rows._id}>
+                <TableCell align="center">
+                  {rows.createAt} <br /> ({rows._id})
+                </TableCell>
+                <TableCell align="center">{rows.products[0].images}</TableCell>
+                <TableCell align="center">{rows.products[0].name}</TableCell>
+                <TableCell align="center">
+                  {rows.products[0].quantity}
+                </TableCell>
+                <TableCell align="center">{rows.state}</TableCell>
+                <TableCell align="center">
+                  <Button type="button">별점등록</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
 }


### PR DESCRIPTION
## 🧾 관련 이슈
close : #26 


## 🔎 구현한 내용
- 구매 내역 더미 데이터 생성
- 내역 테이블 작업 진행


## 📸 스크린샷(선택사항)
<img width="600" alt="구매자 주문내역 테이블" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/8db14541-0140-4dbc-99e1-17de247c304d">


## 🙌 리뷰어에게
- 주문 내역에 대한 API는 다음주 중으로 확인이 될 것 같아 더미 데이터를 사용하여 기본 테이블만 작업했으며, 이후 추가기능에 대해 작업할 예정입니다.
- 마지막 커밋(Feat: 총 구매가격 출력)에 대한 이슈번호는 #10번이 아닌 #26번입니다.


