### PR TITLE
Refactor: 구매자 구매 목록, 판매자 등록 물품 목록 조회 API 연결

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -91,4 +91,7 @@ export const api = {
 
   // 상품 결제
   checkOut: (orderData: any) => axiosInstance.post('/orders/', orderData),
+
+  // 구매자 구매 목록 조회
+  getOrderProductInfo: () => axiosInstance.get('/orders/'),
 };

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'react';
 import { api } from '../../api/api';
 import { IOrderItem } from '../../type';
 import { Link } from 'react-router-dom';
+import { ORDER_STATE } from '../../constants';
 
 export default function BuyerOrdeList() {
   const [orderList, setOrderList] = useState<IOrderItem[]>([]);
@@ -91,7 +92,15 @@ export default function BuyerOrdeList() {
                   {rows.cost.total.toLocaleString()}원<br /> (
                   {rows.cost.shippingFees.toLocaleString()}원)
                 </TableCell>
-                <TableCell align="center">{rows.state}</TableCell>
+                <TableCell align="center">
+                  {ORDER_STATE.codes
+                    .filter((state) => state.code === rows.state)
+                    .map((stateValue) => (
+                      <Typography key={stateValue.code} variant="body2">
+                        {stateValue.value}
+                      </Typography>
+                    ))}
+                </TableCell>
                 <TableCell align="center">
                   <Button type="button" variant="outlined">
                     별점평가

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from 'react';
 
 import { api } from '../../api/api';
 import { IOrderItem } from '../../type';
+import { Link } from 'react-router-dom';
 
 export default function BuyerOrdeList() {
   const [orderList, setOrderList] = useState<IOrderItem[]>([]);
@@ -38,7 +39,20 @@ export default function BuyerOrdeList() {
     getOrderProductInfo();
   }, []);
 
-  console.log('orderList:', orderList);
+  if (orderList.length === 0) {
+    return (
+      <>
+        <Typography variant="h3" sx={{ marginBottom: '1rem' }}>
+          결제 내역이 없습니다.
+        </Typography>
+        <Link to={`/`}>
+          <Button type="button" variant="contained" size="large">
+            구매하러 가기
+          </Button>
+        </Link>
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -7,109 +7,84 @@ import {
   TableCell,
   Paper,
   Button,
+  Typography,
 } from '@mui/material';
+import { useEffect, useState } from 'react';
 
-const dummyUserOderList = [
-  {
-    _id: 1,
-    user_id: 1,
-    state: '0S010',
-    products: [
-      {
-        _id: 1,
-        name: '네파 푸퍼',
-        images: 'imageUrl',
-        quantity: 1,
-        price: 12000,
-      },
-    ],
-    cost: {
-      products: 12000,
-      shippingFees: 2500,
-      total: 14500,
-    },
-    address: {
-      name: '우리집',
-      value: '서울시 강남구 어디동',
-    },
-    createAt: '2023-11-29',
-    updateAt: '2023-11-29',
-  },
-  {
-    _id: 2,
-    user_id: 1,
-    state: '0S010',
-    products: [
-      {
-        _id: 2,
-        name: '등산용 백팩',
-        images: 'imageUrl',
-        quantity: 1,
-        price: 24000,
-      },
-    ],
-    cost: {
-      products: 24000,
-      shippingFees: 3000,
-      total: 27000,
-    },
-    address: {
-      name: '우리집',
-      value: '서울시 강남구 어디동',
-    },
-    createAt: '2023-11-29',
-    updateAt: '2023-11-29',
-  },
-];
+import { api } from '../../api/api';
+import { IOrderItem } from '../../type';
 
 export default function BuyerOrdeList() {
+  const [orderList, setOrderList] = useState<IOrderItem[]>([]);
+
+  // 날짜 변환 함수
+  function formatDate(dateString: string) {
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(new Date(dateString));
+  }
+
+  useEffect(() => {
+    const getOrderProductInfo = async () => {
+      try {
+        const response = await api.getOrderProductInfo();
+        setOrderList(response.data.item);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    getOrderProductInfo();
+  }, []);
+
+  console.log('orderList:', orderList);
+
   return (
     <>
       <TableContainer component={Paper}>
-        <Table aria-label="구매내역">
+        <Table aria-label="결제내역">
           <TableHead>
             <TableRow>
               <TableCell align="center">
-                주문일자
+                결제일
                 <br /> (주문번호)
               </TableCell>
-              <TableCell align="center">이미지</TableCell>
               <TableCell align="center">상품명</TableCell>
               <TableCell align="center">수량</TableCell>
-              <TableCell align="center">상품가격</TableCell>
+              <TableCell align="center">
+                총 결제금액 <br />
+                (배송비)
+              </TableCell>
               <TableCell align="center">주문처리상태</TableCell>
-              <TableCell align="center">별점평가</TableCell>
+              <TableCell align="center"></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {dummyUserOderList.map((rows) => (
+            {orderList.map((rows) => (
               <TableRow key={rows._id}>
                 <TableCell align="center">
-                  {rows.createAt} <br /> ({rows._id})
+                  <Typography variant="body2" color="text.secondary">
+                    {formatDate(rows.createdAt)}
+                  </Typography>
+                  ({rows._id})
                 </TableCell>
-                <TableCell align="center">{rows.products[0].images}</TableCell>
-                <TableCell align="center">{rows.products[0].name}</TableCell>
                 <TableCell align="center">
-                  {rows.products[0].quantity}
+                  {rows.products[0].name} 포함 총 {rows.products.length}건
                 </TableCell>
-                <TableCell align="center">{rows.products[0].price}</TableCell>
+                <TableCell align="center">{rows.products.length}</TableCell>
+                <TableCell align="center">
+                  {rows.cost.total.toLocaleString()}원<br /> (
+                  {rows.cost.shippingFees.toLocaleString()}원)
+                </TableCell>
                 <TableCell align="center">{rows.state}</TableCell>
                 <TableCell align="center">
-                  <Button type="button">별점등록</Button>
+                  <Button type="button" variant="outlined">
+                    별점평가
+                  </Button>
                 </TableCell>
               </TableRow>
             ))}
-            <TableRow>
-              <TableCell align="right" colSpan={7}>
-                총 가격{' '}
-                {dummyUserOderList[0].cost.products +
-                  ' + ' +
-                  dummyUserOderList[0].cost.shippingFees +
-                  ' = ' +
-                  dummyUserOderList[0].cost.total +
-                  '원'}
-              </TableCell>
-            </TableRow>
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -8,12 +8,15 @@ import {
   Paper,
   ToggleButton,
   Typography,
+  Box,
+  Button,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import { useEffect, useState } from 'react';
 
 import { api } from '../../api/api';
 import { IProduct } from '../../type';
+import { CATEGORY } from '../../constants/index';
 
 export default function ProductManager() {
   const _id = localStorage.getItem('_id');
@@ -73,9 +76,19 @@ export default function ProductManager() {
                   <Typography variant="body2" color="text.secondary">
                     {formatDate(rows.createdAt)}
                   </Typography>
-                  {rows._id}
+                  ({rows._id})
                 </TableCell>
-                <TableCell align="center">{rows.extra.category[1]}</TableCell>
+                <TableCell align="center">
+                  {CATEGORY.depth2
+                    .filter(
+                      (category) => category.dbCode === rows.extra.category[1],
+                    )
+                    .map((categoryName) => (
+                      <Typography key={categoryName.id} variant="body2">
+                        {categoryName.name}
+                      </Typography>
+                    ))}
+                </TableCell>
                 <TableCell align="center">
                   <img
                     src={`${rows.mainImages[0]}`}
@@ -85,7 +98,9 @@ export default function ProductManager() {
                 </TableCell>
                 <TableCell align="center">{rows.name}</TableCell>
                 <TableCell align="center">{rows.quantity}</TableCell>
-                <TableCell align="center">{rows.price}</TableCell>
+                <TableCell align="center">
+                  {rows.price.toLocaleString()}원
+                </TableCell>
                 <TableCell align="center">
                   <ToggleButton
                     value="check"
@@ -98,8 +113,21 @@ export default function ProductManager() {
                     <CheckIcon />
                   </ToggleButton>
                 </TableCell>
-                <TableCell>
-                  <button type="button">수정하기</button>
+                <TableCell align="center">
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 1,
+                    }}
+                  >
+                    <Button type="button" variant="contained">
+                      상세보기
+                    </Button>
+                    <Button type="button" variant="contained">
+                      수정하기
+                    </Button>
+                  </Box>
                 </TableCell>
               </TableRow>
             ))}

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -48,6 +48,22 @@ export default function ProductManager() {
     fetchSellerProductData();
   }, []);
 
+  if (productList.length === 0) {
+    return (
+      <>
+        <Typography variant="h3" sx={{ marginBottom: '1rem' }}>
+          등록된 물품이 없습니다.
+        </Typography>
+        <Link to={`/user/${_id}/product-create`}>
+          <Button type="button" variant="contained" size="large">
+            물품 등록하러 가기
+          </Button>
+        </Link>
+      </>
+    );
+  }
+
+  console.log(productList);
   return (
     <>
       <TableContainer component={Paper}>

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -17,10 +17,10 @@ import { useEffect, useState } from 'react';
 import { api } from '../../api/api';
 import { IProduct } from '../../type';
 import { CATEGORY } from '../../constants/index';
+import { Link } from 'react-router-dom';
 
 export default function ProductManager() {
   const _id = localStorage.getItem('_id');
-
   const [productList, setProductList] = useState<IProduct[]>([]);
   const [isShow, setIsShow] = useState(false);
 
@@ -47,8 +47,6 @@ export default function ProductManager() {
     };
     fetchSellerProductData();
   }, []);
-
-  console.log('받아온 데이터:', productList);
 
   return (
     <>
@@ -124,9 +122,14 @@ export default function ProductManager() {
                     <Button type="button" variant="contained">
                       상세보기
                     </Button>
-                    <Button type="button" variant="contained">
-                      수정하기
-                    </Button>
+                    <Link
+                      to={`/user/${rows._id}/product-update`}
+                      state={{ productId: `${rows._id}` }}
+                    >
+                      <Button type="button" variant="contained">
+                        수정하기
+                      </Button>
+                    </Link>
                   </Box>
                 </TableCell>
               </TableRow>

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -63,7 +63,6 @@ export default function ProductManager() {
     );
   }
 
-  console.log(productList);
   return (
     <>
       <TableContainer component={Paper}>
@@ -132,12 +131,15 @@ export default function ProductManager() {
                     sx={{
                       display: 'flex',
                       flexDirection: 'column',
+                      alignItems: 'center',
                       gap: 1,
                     }}
                   >
-                    <Button type="button" variant="contained">
-                      상세보기
-                    </Button>
+                    <Link to={`/product/${rows._id}`}>
+                      <Button type="button" variant="contained">
+                        상세보기
+                      </Button>
+                    </Link>
                     <Link
                       to={`/user/${rows._id}/product-update`}
                       state={{ productId: `${rows._id}` }}

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -7,101 +7,45 @@ import {
   TableCell,
   Paper,
   ToggleButton,
+  Typography,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-const dummySellerProductList = [
-  {
-    item: {
-      _id: 4,
-      seller_id: 7,
-      price: 8000,
-      shippingFees: 3500,
-      show: true,
-      active: true,
-      name: '등산용 양말',
-      images: 'imiageURL',
-      content: '내용',
-      createdAt: '2023-11-29',
-      updatedAt: '2023-11-29',
-      extra: {
-        category: ['H01', 'H0105'],
-        quantity: 1,
-        buyQuantity: 1,
-        order: 0,
-      },
-    },
-  },
-  {
-    item: {
-      _id: 6,
-      seller_id: 7,
-      price: 35000,
-      shippingFees: 3500,
-      show: true,
-      active: true,
-      name: '바람막이',
-      images: 'imiageURL',
-      content: '내용',
-      createdAt: '2023-11-29',
-      updatedAt: '2023-11-29',
-      extra: {
-        category: ['H01', 'H0101'],
-        quantity: 1,
-        buyQuantity: 1,
-        order: 0,
-      },
-    },
-  },
-  {
-    item: {
-      _id: 8,
-      seller_id: 5,
-      price: 20000,
-      shippingFees: 2500,
-      show: true,
-      active: true,
-      name: '등산용 바지',
-      images: 'imiageURL',
-      content: '내용',
-      createdAt: '2023-11-29',
-      updatedAt: '2023-11-29',
-      extra: {
-        category: ['H01', 'H0102'],
-        quantity: 1,
-        buyQuantity: 1,
-        order: 0,
-      },
-    },
-  },
-  {
-    item: {
-      _id: 10,
-      seller_id: 7,
-      price: 40000,
-      shippingFees: 3500,
-      show: true,
-      active: true,
-      name: '등산용 배낭',
-      images: 'imiageURL',
-      content: '내용',
-      createdAt: '2023-11-30',
-      updatedAt: '2023-11-30',
-      extra: {
-        category: ['H01', 'H0105'],
-        quantity: 1,
-        buyQuantity: 1,
-        order: 0,
-      },
-    },
-  },
-];
+import { api } from '../../api/api';
+import { IProduct } from '../../type';
 
 export default function ProductManager() {
   const _id = localStorage.getItem('_id');
 
+  const [productList, setProductList] = useState<IProduct[]>([]);
   const [isShow, setIsShow] = useState(false);
+
+  // 날짜 변환 함수
+  function formatDate(dateString: string) {
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(new Date(dateString));
+  }
+
+  useEffect(() => {
+    const fetchSellerProductData = async () => {
+      try {
+        const response = await api.getProductList();
+        const getMatchItem = response.data.item.filter(
+          (id: IProduct) => id.seller_id === Number(_id),
+        );
+        setProductList(getMatchItem);
+      } catch (error) {
+        console.log('상품 목록을 가져오는데 실패했습니다', error);
+      }
+    };
+    fetchSellerProductData();
+  }, []);
+
+  console.log('받아온 데이터:', productList);
 
   return (
     <>
@@ -123,39 +67,42 @@ export default function ProductManager() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {dummySellerProductList
-              .filter((matchId) => matchId.item.seller_id === Number(_id))
-              .map((rows) => (
-                <TableRow key={rows.item._id}>
-                  <TableCell align="center">
-                    {rows.item.updatedAt} <br /> {rows.item._id}
-                  </TableCell>
-                  <TableCell align="center">
-                    {rows.item.extra.category[1]}
-                  </TableCell>
-                  <TableCell align="center">{rows.item.images}</TableCell>
-                  <TableCell align="center">{rows.item.name}</TableCell>
-                  <TableCell align="center">
-                    {rows.item.extra.quantity}
-                  </TableCell>
-                  <TableCell align="center">{rows.item.price}</TableCell>
-                  <TableCell align="center">
-                    <ToggleButton
-                      value="check"
-                      selected={isShow}
-                      size={'small'}
-                      onChange={() => {
-                        setIsShow(!rows.item.show);
-                      }}
-                    >
-                      <CheckIcon />
-                    </ToggleButton>
-                  </TableCell>
-                  <TableCell>
-                    <button type="button">수정하기</button>
-                  </TableCell>
-                </TableRow>
-              ))}
+            {productList.map((rows) => (
+              <TableRow key={rows._id}>
+                <TableCell align="center">
+                  <Typography variant="body2" color="text.secondary">
+                    {formatDate(rows.createdAt)}
+                  </Typography>
+                  {rows._id}
+                </TableCell>
+                <TableCell align="center">{rows.extra.category[1]}</TableCell>
+                <TableCell align="center">
+                  <img
+                    src={`${rows.mainImages[0]}`}
+                    alt="main-Image"
+                    style={{ width: '80px' }}
+                  />
+                </TableCell>
+                <TableCell align="center">{rows.name}</TableCell>
+                <TableCell align="center">{rows.quantity}</TableCell>
+                <TableCell align="center">{rows.price}</TableCell>
+                <TableCell align="center">
+                  <ToggleButton
+                    value="check"
+                    selected={isShow}
+                    size={'small'}
+                    onChange={() => {
+                      setIsShow(!rows.show);
+                    }}
+                  >
+                    <CheckIcon />
+                  </ToggleButton>
+                </TableCell>
+                <TableCell>
+                  <button type="button">수정하기</button>
+                </TableCell>
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -179,3 +179,80 @@ export const PRICE_MARKS = [
     value: 100000,
   },
 ];
+
+export const ORDER_STATE = {
+  _id: 'orderState',
+  title: '주문 상태',
+  codes: [
+    {
+      sort: 1,
+      code: 'OS010',
+      value: '주문 완료',
+    },
+    {
+      sort: 2,
+      code: 'OS020',
+      value: '결제 완료',
+    },
+    {
+      sort: 3,
+      code: 'OS030',
+      value: '배송 준비중',
+    },
+    {
+      sort: 4,
+      code: 'OS035',
+      value: '배송중',
+    },
+    {
+      sort: 5,
+      code: 'OS040',
+      value: '배송 완료',
+    },
+    {
+      sort: 6,
+      code: 'OS110',
+      value: '반품 요청',
+    },
+    {
+      sort: 7,
+      code: 'OS120',
+      value: '반품 처리중',
+    },
+    {
+      sort: 8,
+      code: 'OS130',
+      value: '반품 완료',
+    },
+    {
+      sort: 9,
+      code: 'OS210',
+      value: '교환 요청',
+    },
+    {
+      sort: 10,
+      code: 'OS220',
+      value: '교환 처리중',
+    },
+    {
+      sort: 11,
+      code: 'OS230',
+      value: '교환 완료',
+    },
+    {
+      sort: 12,
+      code: 'OS310',
+      value: '환불 요청',
+    },
+    {
+      sort: 13,
+      code: 'OS320',
+      value: '환불 처리중',
+    },
+    {
+      sort: 14,
+      code: 'OS330',
+      value: '환불 완료',
+    },
+  ],
+};

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -52,3 +52,19 @@ export interface IUserStore {
   logIn: (token: string) => void;
   logOut: () => void;
 }
+
+export interface IOrderItem {
+  _id: number;
+  user_id: number;
+  state: string;
+  products: IProduct[];
+  cost: {
+    discount: number[];
+    products: number;
+    shippingFees: number;
+    total: number;
+  };
+  address: string[];
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #46 


## 🔎 구현한 내용
- 구매자 구매 내역 목록 조회
- 판매자 등록 상품 내역 목록 조회
   - 각 상품별 상세페이지 이동
   - 각 상품별 수정하기 페이지 이동


## 📸 스크린샷(선택사항)
1️⃣ 주문 내역
<img width="600" alt="스크린샷 2023-12-05 오후 1 21 22" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/366f8617-ea3a-4b00-b6d0-6c58efb06e40">

2️⃣ 주문 내역이 없을 경우(판매 등록 물품도 동일)
<img width="600" alt="스크린샷 2023-12-05 오후 1 17 22" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/78b2b628-8640-4aa5-9955-4fc02e799ec3">

3️⃣ 판매 등록 물품 내역
<img width="600" alt="스크린샷 2023-12-05 오후 1 17 22" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/f167886f-f194-44e6-8264-786f7441d52c">


## 🙌 리뷰어에게
- 구매자 주문 내역에서 주문처리상태 dbCode도 동일하게 상태명으로 변경이 필요합니다.
- 판매자 상품 관리(판매 물품 내역)에서 공개여부 기능은 추후 작업 예정입니다.
- 목록들의 값이 빈 배열일 경우 에러핸들링 처리를 해놨는데, 초기 렌더링 시 초기값이 빈배열이라 잠깐 안내화면이 보였다 사라지는 현상이 있습니다. 이 부분도 추후 좀 더 나은 방법을 고민해보려고 합니다.



