### PR TITLE
Feat: 판매자 정보 조회/수정 페이지 구현

### DIFF
--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -10,6 +10,7 @@ import {
 
 import { api } from '../../api/api';
 import AddressForm from '../address/AddressForm';
+import { IUserInfo } from '../../type/index';
 
 const Form = styled.form`
   display: flex;
@@ -19,16 +20,9 @@ const Form = styled.form`
   gap: 0.5rem;
 `;
 
-export interface IBuyerInfo {
-  _id: number;
-  email: string;
-  name: string;
-  address?: string;
-}
-
 export default function BuyerInfo() {
   const userId = localStorage.getItem('_id');
-  const [buyerInfoData, setBuyerInfoData] = useState<IBuyerInfo>({
+  const [buyerInfoData, setBuyerInfoData] = useState<IUserInfo>({
     _id: 0,
     email: '',
     name: '',

--- a/src/components/seller/SellerInfo.tsx
+++ b/src/components/seller/SellerInfo.tsx
@@ -1,3 +1,101 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import {
+  Container,
+  Typography,
+  TextField,
+  FormLabel,
+  Button,
+} from '@mui/material';
+
+import { api } from '../../api/api';
+import { IUserInfo } from '../../type/index';
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+  width: 100%;
+  gap: 0.5rem;
+`;
+
 export default function SellerInfo() {
-  return <div>SellerInfo</div>;
+  const userId = localStorage.getItem('_id');
+  const [sellerInfoData, setSellerInfoData] = useState<IUserInfo>({
+    _id: 0,
+    email: '',
+    name: '',
+    address: '',
+  });
+
+  const handleChangeUserName = (newName: string) => {
+    setSellerInfoData({
+      ...sellerInfoData,
+      name: newName,
+    });
+  };
+
+  const handleUpdateUserInfo = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      await api.updateUserInfo(userId, sellerInfoData);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    if (!userId) {
+      console.log('ID가 유효하지 않습니다.');
+      return;
+    }
+    const getSellerInfo = async () => {
+      try {
+        const response = await api.getUserInfo(userId);
+        setSellerInfoData({
+          ...sellerInfoData,
+          _id: response.data.item._id,
+          email: response.data.item.email,
+          name: response.data.item.name,
+        });
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    getSellerInfo();
+  }, []);
+
+  return (
+    <Container>
+      {sellerInfoData && (
+        <>
+          <Typography variant="h4">판매자 정보 수정</Typography>
+          <Form onSubmit={handleUpdateUserInfo}>
+            <FormLabel>이메일</FormLabel>
+            <TextField
+              type="email"
+              value={sellerInfoData.email}
+              variant="outlined"
+              size="small"
+              fullWidth
+              required
+              disabled
+            />
+            <FormLabel>이름</FormLabel>
+            <TextField
+              type="text"
+              value={sellerInfoData.name}
+              onChange={(e) => handleChangeUserName(e.target.value)}
+              size="small"
+              fullWidth
+            />
+            <Button type="submit" variant="contained" size="large">
+              판매자 정보 수정하기
+            </Button>
+          </Form>
+        </>
+      )}
+    </Container>
+  );
 }

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -68,3 +68,10 @@ export interface IOrderItem {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface IUserInfo {
+  _id: number;
+  email: string;
+  name: string;
+  address?: string;
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #49


## 🔎 구현한 내용
- 판매자 정보 조회 및 수정 페이지 구현


## 📸 스크린샷(선택사항)
<img width="600" alt="스크린샷 2023-12-05 오후 6 18 20" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/f5fc6901-640e-4b4f-be71-5c3a9c3fe52c">


## 🙌 리뷰어에게
- 구매자 정보 DB와 판매자 정보 DB는 동일합니다.
- 판매자 정보에는 주소 정보를 따로 넣지 않았습니다.
- 추후 변동사항이 있을 경우 반영하겠습니다.

