### PR TITLE
Feat: 판매자 등록 상품 목록 페이지 정렬 기능 추가

### DIFF
--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -10,6 +10,10 @@ import {
   Typography,
   Box,
   Button,
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import { useEffect, useState } from 'react';
@@ -22,6 +26,7 @@ import { Link } from 'react-router-dom';
 export default function ProductManager() {
   const _id = localStorage.getItem('_id');
   const [productList, setProductList] = useState<IProduct[]>([]);
+  const [sortOrder, setSortOrder] = useState('최신순');
   const [isShow, setIsShow] = useState(false);
 
   // 날짜 변환 함수
@@ -65,96 +70,121 @@ export default function ProductManager() {
 
   return (
     <>
-      <TableContainer component={Paper}>
-        <Table aria-label="구매내역">
-          <TableHead>
-            <TableRow>
-              <TableCell align="center">
-                등록일자
-                <br /> (등록번호)
-              </TableCell>
-              <TableCell align="center">카테고리</TableCell>
-              <TableCell align="center">이미지</TableCell>
-              <TableCell align="center">상품명</TableCell>
-              <TableCell align="center">수량</TableCell>
-              <TableCell align="center">가격</TableCell>
-              <TableCell align="center">공개여부</TableCell>
-              <TableCell align="center"></TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {productList.map((rows) => (
-              <TableRow key={rows._id}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: 2,
+        }}
+      >
+        <FormControl>
+          <InputLabel id="sort-label">정렬</InputLabel>
+          <Select
+            labelId="sort-label"
+            id="sort-select"
+            value={sortOrder}
+            size="small"
+            onChange={(e) => setSortOrder(e.target.value)}
+          >
+            <MenuItem value="최신순">최신순</MenuItem>
+            <MenuItem value="오래된순">오래된순</MenuItem>
+            <MenuItem value="가-하">가격: 낮은 순</MenuItem>
+            <MenuItem value="하-가">가격: 높은 순</MenuItem>
+          </Select>
+        </FormControl>
+        <TableContainer component={Paper}>
+          <Table aria-label="구매내역">
+            <TableHead>
+              <TableRow>
                 <TableCell align="center">
-                  <Typography variant="body2" color="text.secondary">
-                    {formatDate(rows.createdAt)}
-                  </Typography>
-                  ({rows._id})
+                  등록일자
+                  <br /> (등록번호)
                 </TableCell>
-                <TableCell align="center">
-                  {CATEGORY.depth2
-                    .filter(
-                      (category) => category.dbCode === rows.extra.category[1],
-                    )
-                    .map((categoryName) => (
-                      <Typography key={categoryName.id} variant="body2">
-                        {categoryName.name}
-                      </Typography>
-                    ))}
-                </TableCell>
-                <TableCell align="center">
-                  <img
-                    src={`${rows.mainImages[0]}`}
-                    alt="main-Image"
-                    style={{ width: '80px' }}
-                  />
-                </TableCell>
-                <TableCell align="center">{rows.name}</TableCell>
-                <TableCell align="center">{rows.quantity}</TableCell>
-                <TableCell align="center">
-                  {rows.price.toLocaleString()}원
-                </TableCell>
-                <TableCell align="center">
-                  <ToggleButton
-                    value="check"
-                    selected={isShow}
-                    size={'small'}
-                    onChange={() => {
-                      setIsShow(!rows.show);
-                    }}
-                  >
-                    <CheckIcon />
-                  </ToggleButton>
-                </TableCell>
-                <TableCell align="center">
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      gap: 1,
-                    }}
-                  >
-                    <Link to={`/product/${rows._id}`}>
-                      <Button type="button" variant="contained">
-                        상세보기
-                      </Button>
-                    </Link>
-                    <Link
-                      to={`/user/${rows._id}/product-update`}
-                      state={{ productId: `${rows._id}` }}
-                    >
-                      <Button type="button" variant="contained">
-                        수정하기
-                      </Button>
-                    </Link>
-                  </Box>
-                </TableCell>
+                <TableCell align="center">카테고리</TableCell>
+                <TableCell align="center">이미지</TableCell>
+                <TableCell align="center">상품명</TableCell>
+                <TableCell align="center">수량</TableCell>
+                <TableCell align="center">가격</TableCell>
+                <TableCell align="center">공개여부</TableCell>
+                <TableCell align="center"></TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+            </TableHead>
+            <TableBody>
+              {productList.map((rows) => (
+                <TableRow key={rows._id}>
+                  <TableCell align="center">
+                    <Typography variant="body2" color="text.secondary">
+                      {formatDate(rows.createdAt)}
+                    </Typography>
+                    ({rows._id})
+                  </TableCell>
+                  <TableCell align="center">
+                    {CATEGORY.depth2
+                      .filter(
+                        (category) =>
+                          category.dbCode === rows.extra.category[1],
+                      )
+                      .map((categoryName) => (
+                        <Typography key={categoryName.id} variant="body2">
+                          {categoryName.name}
+                        </Typography>
+                      ))}
+                  </TableCell>
+                  <TableCell align="center">
+                    <img
+                      src={`${rows.mainImages[0]}`}
+                      alt="main-Image"
+                      style={{ width: '80px' }}
+                    />
+                  </TableCell>
+                  <TableCell align="center">{rows.name}</TableCell>
+                  <TableCell align="center">{rows.quantity}</TableCell>
+                  <TableCell align="center">
+                    {rows.price.toLocaleString()}원
+                  </TableCell>
+                  <TableCell align="center">
+                    <ToggleButton
+                      value="check"
+                      selected={isShow}
+                      size={'small'}
+                      onChange={() => {
+                        setIsShow(!rows.show);
+                      }}
+                    >
+                      <CheckIcon />
+                    </ToggleButton>
+                  </TableCell>
+                  <TableCell align="center">
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: 1,
+                      }}
+                    >
+                      <Link to={`/product/${rows._id}`}>
+                        <Button type="button" variant="contained">
+                          상세보기
+                        </Button>
+                      </Link>
+                      <Link
+                        to={`/user/${rows._id}/product-update`}
+                        state={{ productId: `${rows._id}` }}
+                      >
+                        <Button type="button" variant="contained">
+                          수정하기
+                        </Button>
+                      </Link>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
     </>
   );
 }

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -26,6 +26,7 @@ import { Link } from 'react-router-dom';
 export default function ProductManager() {
   const _id = localStorage.getItem('_id');
   const [productList, setProductList] = useState<IProduct[]>([]);
+  const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);
   const [sortOrder, setSortOrder] = useState('최신순');
   const [isShow, setIsShow] = useState(false);
 
@@ -52,6 +53,34 @@ export default function ProductManager() {
     };
     fetchSellerProductData();
   }, []);
+
+  // SORT 정렬
+  useEffect(() => {
+    let sorted = [...productList];
+    switch (sortOrder) {
+      case '최신순':
+        sorted.sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+        break;
+      case '오래된순':
+        sorted.sort(
+          (a, b) =>
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        );
+        break;
+      case '가-하':
+        sorted.sort((a, b) => a.price - b.price);
+        break;
+      case '하-가':
+        sorted.sort((a, b) => b.price - a.price);
+        break;
+      default:
+        break;
+    }
+    setSortedProductList(sorted);
+  }, [productList, sortOrder]);
 
   if (productList.length === 0) {
     return (
@@ -111,7 +140,7 @@ export default function ProductManager() {
               </TableRow>
             </TableHead>
             <TableBody>
-              {productList.map((rows) => (
+              {sortedProductList.map((rows) => (
                 <TableRow key={rows._id}>
                   <TableCell align="center">
                     <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## 🧾 관련 이슈
close : #52 


## 🔎 구현한 내용
- 판매자 등록 상품 목록에 대해 "최신순, 오래된순, 가격 낮은순, 가격 높은순" 정렬 적용


## 📸 스크린샷(선택사항)
<img width="600" alt="order-list-sort" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/3277b446-7e3e-4634-8cbd-949c530a7ff3">


## 🙌 리뷰어에게
- 우선은 카테고리 검색 뷰에서 사용하는 정렬과 동일하게 구현했으며, 추후 변경 필요시 수정할 예정입니다.
- 정렬 부분이 여러군데에서 재사용되어서 컴포넌트로 빼도 좋을 것 같습니다.

