### PR TITLE
Feat: 구매자 대시보드 최근 본 상품 기능 구현

### DIFF
--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Card,
   CardActionArea,
   CardMedia,
@@ -11,8 +12,21 @@ import {
 import { Link } from 'react-router-dom';
 
 export default function BuyerRecentlyView() {
-  const getData = localStorage.getItem('recentlyViewed');
-  const viewItems = JSON.parse(getData).state.viewItems;
+  const getData = localStorage?.getItem('recentlyViewed');
+  const viewItems = JSON.parse(getData)?.state?.viewItems;
+
+  if (!viewItems || viewItems?.length === 0) {
+    return (
+      <>
+        <Typography variant="h6">최근 본 상품이 없습니다.</Typography>
+        <Link to={`/`}>
+          <Button type="button" variant="outlined" size="medium">
+            상품 보러 가기
+          </Button>
+        </Link>
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -14,8 +14,6 @@ export default function BuyerRecentlyView() {
   const getData = localStorage.getItem('recentlyViewed');
   const viewItems = JSON.parse(getData).state.viewItems;
 
-  console.log('상품 목록', viewItems);
-
   return (
     <>
       <Container>

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -1,5 +1,86 @@
-import React from 'react';
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardMedia,
+  Container,
+  Grid,
+  Grow,
+  IconButton,
+  Typography,
+  styled,
+} from '@mui/material';
+
+import { Link } from 'react-router-dom';
 
 export default function BuyerRecentlyView() {
-  return <div>BuyerRecentlyView</div>;
+  const getData = localStorage.getItem('recentlyViewed');
+  const viewItems = JSON.parse(getData).state.viewItems;
+
+  console.log('상품 목록', viewItems);
+
+  return (
+    <>
+      <Container>
+        {viewItems.map((product) => (
+          <StyledCard>
+            <CardActionArea component={Link} to={`/product/${product._id}`}>
+              <ProductImage
+                image={product.mainImages[0]}
+                title={product.name}
+              />
+              <ProductDetails>
+                <Typography variant="h6">{product.name}</Typography>
+                <Typography variant="h6" color="inherit" fontWeight={700}>
+                  {product.price.toLocaleString()} 원
+                </Typography>
+              </ProductDetails>
+            </CardActionArea>
+            <ProductActions>
+              <ShippingFee>
+                <Typography variant="body2">
+                  {product.shippingFees === 0
+                    ? '무료배송'
+                    : '배송료: ' + product.shippingFees.toLocaleString() + '원'}
+                </Typography>
+              </ShippingFee>
+            </ProductActions>
+          </StyledCard>
+        ))}
+      </Container>
+    </>
+  );
 }
+
+const StyledCard = styled(Card)({
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
+  boxShadow: 'none',
+  borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+});
+
+const ProductImage = styled(CardMedia)({
+  height: '200px',
+  backgroundSize: 'cover',
+  backgroundColor: 'grey.50',
+});
+
+const ProductDetails = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  padding: '16px',
+});
+
+const ProductActions = styled(Box)({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  padding: '8px',
+});
+
+const ShippingFee = styled(Box)({
+  flexGrow: 1,
+  padding: '0 8px',
+});

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -12,8 +12,8 @@ import {
 import { Link } from 'react-router-dom';
 
 export default function BuyerRecentlyView() {
-  const getData = localStorage?.getItem('recentlyViewed');
-  const viewItems = JSON.parse(getData)?.state?.viewItems;
+  const recentlyViewedItems = localStorage?.getItem('recentlyViewed');
+  const viewItems = JSON.parse(recentlyViewedItems)?.state?.viewItems;
 
   if (!viewItems || viewItems?.length === 0) {
     return (

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function BuyerRecentlyView() {
+  return <div>BuyerRecentlyView</div>;
+}

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -21,7 +21,7 @@ export default function BuyerRecentlyView() {
           <StyledCard key={product._id}>
             <CardActionArea component={Link} to={`/product/${product._id}`}>
               <ProductImage
-                image={product.mainImages[0]}
+                image={product.mainImages[0].path}
                 title={product.name}
               />
               <ProductDetails>

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -4,9 +4,6 @@ import {
   CardActionArea,
   CardMedia,
   Container,
-  Grid,
-  Grow,
-  IconButton,
   Typography,
   styled,
 } from '@mui/material';
@@ -23,7 +20,7 @@ export default function BuyerRecentlyView() {
     <>
       <Container>
         {viewItems.map((product) => (
-          <StyledCard>
+          <StyledCard key={product._id}>
             <CardActionArea component={Link} to={`/product/${product._id}`}>
               <ProductImage
                 image={product.mainImages[0]}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,7 +25,7 @@ export const DASHBOARD_MENU = {
     {
       id: 5,
       title: '최근 본 상품',
-      url: `/user/${_id}/buyer-orderlist`,
+      url: `/user/${_id}/recently-viewed-items`,
     },
   ],
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand';
-import { ICartItem, ICartStore, ISearchState } from '../type';
+import {
+  ICartItem,
+  ICartStore,
+  ISearchState,
+  IProduct,
+  IRecentlyViewdStore,
+} from '../type';
 import { persist } from 'zustand/middleware';
 
 // 로그인 상태 관리 store
@@ -68,3 +74,33 @@ export const useSearchStore = create<ISearchState>((set) => ({
   setSearchQuery: (query) => set({ searchQuery: query }),
   setSearchResult: (result) => set({ searchResult: result }),
 }));
+
+// 최근 본 상품 store
+export const useRecentViewProductStore = create(
+  persist(
+    (set) => ({
+      viewItems: [],
+      addRecentViewProduct: (recentlyItem: IProduct) => {
+        set((state: IRecentlyViewdStore) => {
+          const checkingSameIndex = state.viewItems.findIndex(
+            (item) => item._id === recentlyItem._id,
+          );
+          if (checkingSameIndex !== -1) {
+            return state;
+          } else {
+            const updateViewItems = [
+              recentlyItem,
+              ...state.viewItems.slice(0, 9),
+            ];
+            return {
+              viewItems: updateViewItems,
+            };
+          }
+        });
+      },
+    }),
+    {
+      name: 'recentlyViewed',
+    },
+  ),
+);

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -4,7 +4,7 @@ import {
   ICartStore,
   ISearchState,
   IProduct,
-  IRecentlyViewdStore,
+  IRecentlyViewedStore,
 } from '../type';
 import { persist } from 'zustand/middleware';
 
@@ -81,7 +81,7 @@ export const useRecentViewProductStore = create(
     (set) => ({
       viewItems: [],
       addRecentViewProduct: (recentlyItem: IProduct) => {
-        set((state: IRecentlyViewdStore) => {
+        set((state: IRecentlyViewedStore) => {
           const checkingSameIndex = state.viewItems.findIndex(
             (item) => item._id === recentlyItem._id,
           );

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -88,12 +88,12 @@ export const useRecentViewProductStore = create(
           if (checkingSameIndex !== -1) {
             return state;
           } else {
-            const updateViewItems = [
+            const recentlyUpdateViewItems = [
               recentlyItem,
               ...state.viewItems.slice(0, 9),
             ];
             return {
-              viewItems: updateViewItems,
+              viewItems: recentlyUpdateViewItems,
             };
           }
         });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,7 @@ import SignUpPage from './pages/user/SignUp.tsx';
 import { CategoryList } from './pages/product/CategoryList.tsx';
 import { SearchPage } from './pages/product/SearchPage.tsx';
 import CheckOut from './pages/user/CheckOut.tsx';
+import BuyerRecentlyView from './components/buyer/BuyerRecentlyView.tsx';
 
 const router = createBrowserRouter([
   {
@@ -76,6 +77,10 @@ const router = createBrowserRouter([
       {
         path: '/user/:id/seller-orderlist',
         element: <SellerOrderList />,
+      },
+      {
+        path: '/user/:id/recently-viewed-items',
+        element: <BuyerRecentlyView />,
       },
     ],
   },

--- a/src/pages/product/SearchPage.tsx
+++ b/src/pages/product/SearchPage.tsx
@@ -18,7 +18,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 
 import ProductCard from './ProductCard';
 import { SearchSection } from '../../components/search/SearchSection';
-import { useSearchStore } from '../../lib/store';
+import { useSearchStore, useRecentViewProductStore } from '../../lib/store';
 import StickyNavbar from '../../components/NavigationBar';
 import { useSort } from '../../hooks/useSort';
 import { useEffect, useState } from 'react';
@@ -42,6 +42,15 @@ export function SearchPage() {
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedPrice, setSelectedPrice] = useState('전체');
   const [selectedShippingFee, setSelectedShippingFee] = useState('전체');
+
+  const { addRecentViewProduct } = useRecentViewProductStore() as {
+    addRecentViewProduct: Function;
+  };
+
+  // useAddRecentlyViewed(product);
+  const handleSaveRecentlyViewed = (product) => {
+    addRecentViewProduct({ ...product });
+  };
 
   function toggleSidebar() {
     setIsSidebarOpen(!isSidebarOpen);
@@ -106,6 +115,7 @@ export function SearchPage() {
           key={product._id}
           style={{ transformOrigin: '0 0 0' }}
           {...{ timeout: 1000 }}
+          onClick={() => handleSaveRecentlyViewed(product)}
         >
           <Grid item {...getItemSize()}>
             <ProductCard product={product} />

--- a/src/pages/product/SearchPage.tsx
+++ b/src/pages/product/SearchPage.tsx
@@ -61,7 +61,6 @@ export function SearchPage() {
       try {
         const response = await api.getProductList();
         setSearchResult(response.data.item);
-        console.log('상품 검색 성공:', response.data.item);
       } catch (error) {
         console.error('상품 검색 실패:', error);
       }

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -95,7 +95,7 @@ export interface ISearchState {
   setSearchResult: (result: any[]) => void;
 }
 
-export interface IRecentlyViewdStore {
+export interface IRecentlyViewedStore {
   viewdItems: IProduct[];
   addRecentViewProduct: (newItem: IProduct) => void;
 }

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -83,3 +83,8 @@ export interface ISearchState {
   setSearchQuery: (query: string) => void;
   setSearchResult: (result: any[]) => void;
 }
+
+export interface IRecentlyViewdStore {
+  viewdItems: IProduct[];
+  addRecentViewProduct: (newItem: IProduct) => void;
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #78 


## 🔎 구현한 내용
- zustand 상태관리 이용하여 로컬 스토리지에 상품 데이터 10개 저장
  - 가장 최신에 본 데이터가 배열 첫번째로 들어감
  - 중복되는 상품 정보는 저장하지 않음
- 대시보드에서 목록 리스트 확인 가능
  - 리스트의 상품을 클릭하면 상세페이지로 이동함


## 📸 스크린샷(선택사항)
<img width="700" alt="스크린샷 2023-12-14 오후 8 54 41" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/7c260e96-8573-48e1-8cb4-4f0c385c3277">



## 🙌 리뷰어에게
- 로컬 스토리지에 저장된 데이터를 받아와 화면에 렌더링하고 있어 계정이 변경되어도 최근 본 목록의 데이터는 브라우저의 스토리지 저장값 기준으로 동일하게 유지됩니다. (장바구니도 마찬가지)
  - 해당 부분 강사님께 여쭤본 결과, 각 유저별로 상태값을 관리하고 싶다면 DB에 데이터를 저장하는 것을 추천해주셨습니다.

