### PR TITLE
Feat: 북마크 목록 조회 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -189,4 +189,7 @@ export const api = {
   // 북마크 제거
   removeBookmark: (bookmark_id: number) =>
     axiosInstance.delete(`/bookmarks/${bookmark_id}`),
+
+  // 내 북마크 목록 조회
+  getMyBookMark: () => axiosInstance.get('/bookmarks/'),
 };

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../../api/api';
+import CustomSnackbar from '../CustomSnackbar';
 import {
   Box,
   Button,
@@ -15,12 +16,15 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import { Link } from 'react-router-dom';
 
 export default function BuyerFavorite() {
-  const [myBookMarkList, setMyBookMarkList] = useState([]);
+  const [myBookmarkList, setMyBookmarkList] = useState([]);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+  const [deleteBookmarkSuccess, setDeleteBookmarkSuccess] = useState(false);
 
   const fetchBookmark = async () => {
     try {
       const response = await api.getMyBookMark();
-      setMyBookMarkList(response.data.item);
+      setMyBookmarkList(response.data.item);
     } catch (error) {
       console.log('북마크 조회를 실패했습니다.');
     }
@@ -37,14 +41,17 @@ export default function BuyerFavorite() {
       try {
         await api.removeBookmark(Number(bookmarkId));
         fetchBookmark();
-        alert('북마크가 삭제되었습니다.');
+        setDeleteBookmarkSuccess(true);
+        setSnackbarMessage('북마크가 삭제되었습니다.');
+        setSnackbarOpen(true);
       } catch (error) {
+        setDeleteBookmarkSuccess(false);
         console.log('북마크 삭제에 실패했습니다.');
       }
     }
   };
 
-  if (!myBookMarkList || myBookMarkList?.length === 0) {
+  if (!myBookmarkList || myBookmarkList?.length === 0) {
     return (
       <>
         <Typography variant="h6">북마크된 상품이 없습니다.</Typography>
@@ -59,7 +66,7 @@ export default function BuyerFavorite() {
 
   return (
     <Container>
-      {myBookMarkList
+      {myBookmarkList
         .map((bookmark) => (
           <StyledCard key={bookmark._id}>
             <CardActionArea
@@ -86,6 +93,12 @@ export default function BuyerFavorite() {
         ))
         .sort()
         .reverse()}
+      <CustomSnackbar
+        open={snackbarOpen}
+        message={snackbarMessage}
+        handleClose={() => setSnackbarOpen(false)}
+        severity={deleteBookmarkSuccess ? 'success' : 'error'}
+      />
     </Container>
   );
 }
@@ -115,5 +128,5 @@ const ProductActions = styled(Box)({
   display: 'flex',
   justifyContent: 'flex-end',
   alignItems: 'center',
-  padding: '8px',
+  padding: '4px',
 });

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -40,10 +40,26 @@ export default function BuyerFavorite() {
     if (confirmRemoveBookmark) {
       try {
         await api.removeBookmark(Number(bookmarkId));
-        fetchBookmark();
         setDeleteBookmarkSuccess(true);
         setSnackbarMessage('북마크가 삭제되었습니다.');
         setSnackbarOpen(true);
+        setTimeout(() => {
+          fetchBookmark();
+        }, 500);
+
+        if (deleteBookmarkSuccess) {
+          return (
+            <>
+              <CustomSnackbar
+                open={snackbarOpen}
+                message={snackbarMessage}
+                handleClose={() => setSnackbarOpen(false)}
+                severity={deleteBookmarkSuccess ? 'success' : 'error'}
+              />
+              ;
+            </>
+          );
+        }
       } catch (error) {
         console.log('북마크 삭제에 실패했습니다.');
         setSnackbarMessage('북마크 삭제에 실패했습니다.');

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -9,24 +9,40 @@ import {
   Container,
   Typography,
   styled,
+  IconButton,
 } from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 import { Link } from 'react-router-dom';
 
 export default function BuyerFavorite() {
   const [myBookMarkList, setMyBookMarkList] = useState([]);
 
-  useEffect(() => {
-    const fetchBookmark = async () => {
-      try {
-        const response = await api.getMyBookMark();
-        setMyBookMarkList(response.data.item);
-      } catch (error) {
-        console.log('북마크 조회를 실패했습니다.');
-      }
-    };
+  const fetchBookmark = async () => {
+    try {
+      const response = await api.getMyBookMark();
+      setMyBookMarkList(response.data.item);
+    } catch (error) {
+      console.log('북마크 조회를 실패했습니다.');
+    }
+  };
 
+  useEffect(() => {
     fetchBookmark();
   }, []);
+
+  const handleBookmark = async (bookmarkId) => {
+    const confirmRemoveBookmark = window.confirm('북마크를 삭제하시겠습니까?');
+
+    if (confirmRemoveBookmark) {
+      try {
+        await api.removeBookmark(Number(bookmarkId));
+        fetchBookmark();
+        alert('북마크가 삭제되었습니다.');
+      } catch (error) {
+        console.log('북마크 삭제에 실패했습니다.');
+      }
+    }
+  };
 
   if (!myBookMarkList || myBookMarkList?.length === 0) {
     return (
@@ -61,6 +77,11 @@ export default function BuyerFavorite() {
                 </Typography>
               </ProductDetails>
             </CardActionArea>
+            <ProductActions>
+              <IconButton onClick={() => handleBookmark(bookmark._id)}>
+                <FavoriteIcon />
+              </IconButton>
+            </ProductActions>
           </StyledCard>
         ))
         .sort()
@@ -88,4 +109,11 @@ const ProductDetails = styled(Box)({
   flexDirection: 'column',
   alignItems: 'start',
   padding: '16px',
+});
+
+const ProductActions = styled(Box)({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  padding: '8px',
 });

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -1,3 +1,83 @@
+import { useEffect, useState } from 'react';
+import { api } from '../../api/api';
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardMedia,
+  Container,
+  Typography,
+  styled,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+
 export default function BuyerFavorite() {
-  return <>내가 찜한 상품</>;
+  const [myBookMarkList, setMyBookMarkList] = useState([]);
+
+  useEffect(() => {
+    const fetchBookmark = async () => {
+      try {
+        const response = await api.getMyBookMark();
+        setMyBookMarkList(response.data.item);
+        console.log(response.data.item);
+      } catch (error) {
+        console.log('북마크 조회를 실패했습니다.');
+      }
+    };
+
+    fetchBookmark();
+  }, []);
+
+  return (
+    <Container>
+      {myBookMarkList.map((bookmark) => (
+        <StyledCard key={bookmark._id}>
+          <CardActionArea
+            component={Link}
+            to={`/product/${bookmark.product_id}`}
+          >
+            <ProductImage
+              image={bookmark.product.image.path}
+              title={bookmark.product.name}
+            />
+            <ProductDetails>
+              <Typography variant="h6">{bookmark.product.name}</Typography>
+              <Typography variant="h6" color="inherit" fontWeight={700}>
+                {bookmark.product.price.toLocaleString()} 원
+              </Typography>
+            </ProductDetails>
+          </CardActionArea>
+          <ProductActions></ProductActions>
+        </StyledCard>
+      ))}
+    </Container>
+  );
 }
+
+const StyledCard = styled(Card)({
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
+  boxShadow: 'none',
+  borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+});
+
+const ProductImage = styled(CardMedia)({
+  height: '200px',
+  backgroundSize: 'cover',
+  backgroundColor: 'grey.50',
+});
+
+const ProductDetails = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  padding: '16px',
+});
+
+const ProductActions = styled(Box)({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  padding: '8px',
+});

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -45,8 +45,10 @@ export default function BuyerFavorite() {
         setSnackbarMessage('북마크가 삭제되었습니다.');
         setSnackbarOpen(true);
       } catch (error) {
-        setDeleteBookmarkSuccess(false);
         console.log('북마크 삭제에 실패했습니다.');
+        setSnackbarMessage('북마크 삭제에 실패했습니다.');
+        setSnackbarOpen(true);
+        setDeleteBookmarkSuccess(false);
       }
     }
   };

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -43,25 +43,28 @@ export default function BuyerFavorite() {
 
   return (
     <Container>
-      {myBookMarkList.map((bookmark) => (
-        <StyledCard key={bookmark._id}>
-          <CardActionArea
-            component={Link}
-            to={`/product/${bookmark.product_id}`}
-          >
-            <ProductImage
-              image={bookmark.product.image.path}
-              title={bookmark.product.name}
-            />
-            <ProductDetails>
-              <Typography variant="h6">{bookmark.product.name}</Typography>
-              <Typography variant="h6" color="inherit" fontWeight={700}>
-                {bookmark.product.price.toLocaleString()} 원
-              </Typography>
-            </ProductDetails>
-          </CardActionArea>
-        </StyledCard>
-      ))}
+      {myBookMarkList
+        .map((bookmark) => (
+          <StyledCard key={bookmark._id}>
+            <CardActionArea
+              component={Link}
+              to={`/product/${bookmark.product_id}`}
+            >
+              <ProductImage
+                image={bookmark.product.image.path}
+                title={bookmark.product.name}
+              />
+              <ProductDetails>
+                <Typography variant="h6">{bookmark.product.name}</Typography>
+                <Typography variant="h6" color="inherit" fontWeight={700}>
+                  {bookmark.product.price.toLocaleString()} 원
+                </Typography>
+              </ProductDetails>
+            </CardActionArea>
+          </StyledCard>
+        ))
+        .sort()
+        .reverse()}
     </Container>
   );
 }

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { api } from '../../api/api';
 import {
   Box,
+  Button,
   Card,
   CardActionArea,
   CardMedia,
@@ -19,7 +20,6 @@ export default function BuyerFavorite() {
       try {
         const response = await api.getMyBookMark();
         setMyBookMarkList(response.data.item);
-        console.log(response.data.item);
       } catch (error) {
         console.log('북마크 조회를 실패했습니다.');
       }
@@ -27,6 +27,19 @@ export default function BuyerFavorite() {
 
     fetchBookmark();
   }, []);
+
+  if (!myBookMarkList || myBookMarkList?.length === 0) {
+    return (
+      <>
+        <Typography variant="h6">북마크된 상품이 없습니다.</Typography>
+        <Link to={`/`}>
+          <Button type="button" variant="outlined" size="medium">
+            상품 보러 가기
+          </Button>
+        </Link>
+      </>
+    );
+  }
 
   return (
     <Container>
@@ -47,7 +60,6 @@ export default function BuyerFavorite() {
               </Typography>
             </ProductDetails>
           </CardActionArea>
-          <ProductActions></ProductActions>
         </StyledCard>
       ))}
     </Container>
@@ -73,11 +85,4 @@ const ProductDetails = styled(Box)({
   flexDirection: 'column',
   alignItems: 'start',
   padding: '16px',
-});
-
-const ProductActions = styled(Box)({
-  display: 'flex',
-  justifyContent: 'flex-end',
-  alignItems: 'center',
-  padding: '8px',
 });


### PR DESCRIPTION
## 🧾 관련 이슈
close : #81 


## 🔎 구현한 내용
- 내 북마크 api 목록 조회
- 받아온 데이터 화면에 렌더링(가장 최근에 클릭한 제품이 상단에 오도록)
- 북마크 삭제 기능 구현


## 📸 스크린샷(선택사항)
<img width="700" alt="스크린샷 2023-12-14 오후 8 54 41" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/6ff620b4-003b-4364-980e-07c9592d9788">


## 🙌 리뷰어에게
- 북마크 리스트에서 장바구니 버튼도 바로 연결하고 싶었으나 북마크 통신으로 받아오는 API의 응답값과 장바구니에서 받아오는 API의 응답값이 달라서 에러가 발생했었습니다. 그래서 우선 북마크 삭제 기능만 구현했으니 참고 부탁드립니다!
- 리스트 아이템이 하나 남았을 때 삭제를 하게되면 스넥바가 뜨는 속도보다 통신 속도가 더 빠른 듯 합니다. 그래서 빈배열을 리턴하는 응답값에 대해 JSX 조건식에 따라 렌더링되는 속도가 더 빨라서 스넥바가 보이지 않습니다. 이 부분은 어떻게 해결할 수 있을지 좀 더 고민해보려고 합니다.

