### PR TITLE
Feat: 판매 상품 목록 페이지 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -176,6 +176,13 @@ export const api = {
   // 구매자 구매 목록 조회
   getOrderProductInfo: () => axiosInstance.get('/orders/'),
 
+  //판매자 주문 목록 조회
+  getOrderCondition: () => axiosInstance.get('seller/orders/'),
+
+  //판매자 주문상태 관리
+  updateOrderState: (product_id: number) =>
+    axiosInstance.patch(`/seller/orders/${product_id}`, product_id),
+
   // 북마크 조회
   getBookmark: (product_id: number) =>
     axiosInstance.get(`/bookmarks/products/${product_id}`),

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -177,7 +177,7 @@ export const api = {
   getOrderProductInfo: () => axiosInstance.get('/orders/'),
 
   //판매자 주문 목록 조회
-  getOrderCondition: () => axiosInstance.get('seller/orders/'),
+  getOrderState: () => axiosInstance.get('seller/orders/'),
 
   //판매자 주문상태 관리
   updateOrderState: (product_id: number) =>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -168,8 +168,7 @@ export const api = {
     }),
 
   // 판매자 상품 목록 조회
-  getSellerProductInfo: (_id: number) =>
-    axiosInstance.get(`/seller/products/${_id}`),
+  getSellerProductInfo: () => axiosInstance.get(`/seller/products/`),
 
   // 상품 결제
   checkOut: (orderData: any) => axiosInstance.post('/orders/', orderData),

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -22,7 +22,7 @@ import CheckIcon from '@mui/icons-material/Check';
 
 import { api } from '../../api/api';
 import { IProduct, IOrderItem } from '../../type';
-import { CATEGORY, QUALITY, ORDER_STATE } from '../../constants/index';
+import { QUALITY, ORDER_STATE } from '../../constants/index';
 import formatDate from '../../lib/formatDate';
 
 export default function ProductManager() {
@@ -47,7 +47,6 @@ export default function ProductManager() {
       console.log('판매 상품 조회 실패', error);
     }
   };
-  console.log('productList', productList);
 
   useEffect(() => {
     const getOrderState = async () => {
@@ -177,7 +176,7 @@ export default function ProductManager() {
                   <TableCell align="center">
                     <img
                       src={`${rows.mainImages[0].path}`}
-                      alt="main-Image"
+                      alt={`${rows.mainImages[0].id}`}
                       style={{
                         width: '80px',
                         height: '80px',

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -186,9 +186,7 @@ export default function ProductManager() {
                     />
                   </TableCell>
                   <TableCell align="center">
-                    <Link to={`http://localhost:5173/product/${rows._id}`}>
-                      {rows.name}
-                    </Link>
+                    <Link to={`/product/${rows._id}`}>{rows.name}</Link>
                   </TableCell>
                   <TableCell align="center">
                     {rows.extra.sort

--- a/src/components/seller/ProductManager.tsx
+++ b/src/components/seller/ProductManager.tsx
@@ -20,7 +20,7 @@ import { useEffect, useState } from 'react';
 
 import { api } from '../../api/api';
 import { IProduct } from '../../type';
-import { CATEGORY } from '../../constants/index';
+import { CATEGORY, QUALITY } from '../../constants/index';
 import { Link } from 'react-router-dom';
 
 export default function ProductManager() {
@@ -168,7 +168,10 @@ export default function ProductManager() {
                     />
                   </TableCell>
                   <TableCell align="center">{rows.name}</TableCell>
-                  <TableCell align="center">{rows.quantity}</TableCell>
+                  <TableCell align="center">
+                    {QUALITY.find((quality) => quality.value === rows.quantity)
+                      ?.name || '상급'}
+                  </TableCell>
                   <TableCell align="center">
                     {rows.price.toLocaleString()}원
                   </TableCell>

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -21,8 +21,8 @@ import {
 import CheckIcon from '@mui/icons-material/Check';
 
 import { api } from '../../api/api';
-import { IProduct } from '../../type';
-import { CATEGORY, QUALITY } from '../../constants/index';
+import { IProduct, IOrderItem } from '../../type';
+import { CATEGORY, QUALITY, ORDER_STATE } from '../../constants/index';
 
 export default function SellerOrderList() {
   const _id = localStorage.getItem('_id');
@@ -31,6 +31,7 @@ export default function SellerOrderList() {
   const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);
   const [sortOrder, setSortOrder] = useState('최신순');
   const [isShow, setIsShow] = useState(false);
+  const [orderList, setOrderList] = useState<IOrderItem[]>([]);
 
   useEffect(() => {
     fetchSellerProduct();
@@ -138,6 +139,7 @@ export default function SellerOrderList() {
                 <TableCell align="center">품질</TableCell>
                 <TableCell align="center">가격</TableCell>
                 <TableCell align="center">배송료</TableCell>
+                <TableCell align="center">주문상태</TableCell>
                 <TableCell align="center">공개여부</TableCell>
                 <TableCell align="center"></TableCell>
               </TableRow>
@@ -194,6 +196,11 @@ export default function SellerOrderList() {
                   </TableCell>
                   <TableCell align="center">
                     {rows.shippingFees.toLocaleString()}원
+                  </TableCell>
+                  <TableCell align="center">
+                    {ORDER_STATE.codes.find(
+                      (state) => state.code === orderList[0]?.state,
+                    )?.value || 'Unknown State'}
                   </TableCell>
                   <TableCell align="center">
                     <ToggleButton

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -55,6 +55,23 @@ export default function SellerOrderList() {
       console.log('판매 상품 조회 실패', error);
     }
   };
+
+  useEffect(() => {
+    const getOrderCondition = async () => {
+      try {
+        const response = await api.getOrderCondition();
+        const orderState = response.data.item;
+        // console.log('판매상품의 주문상태 불러오기', orderState);
+        setOrderList(orderState);
+      } catch (error) {
+        console.log('주문상태오류', error);
+      }
+    };
+
+    getOrderCondition();
+  }, []);
+
+  console.log('주문상태 상태값', orderList);
   useEffect(() => {
     let sorted = [...productList];
     switch (sortOrder) {
@@ -198,9 +215,12 @@ export default function SellerOrderList() {
                     {rows.shippingFees.toLocaleString()}원
                   </TableCell>
                   <TableCell align="center">
-                    {ORDER_STATE.codes.find(
-                      (state) => state.code === orderList[0]?.state,
-                    )?.value || 'Unknown State'}
+                    {/* {ORDER_STATE.codes.find(
+                      (state) =>
+                        state.code ===
+                        (orderList[0].find((order) => order._id === rows._id)
+                          ?.state || null),
+                    )} */}
                   </TableCell>
                   <TableCell align="center">
                     <ToggleButton

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -137,7 +137,7 @@ export default function SellerOrderList() {
       return orderStateCode ? orderStateCode.value : 'Unknown Order State';
     }
 
-    return '주문 없음';
+    return '판매중';
   };
   return (
     <>
@@ -240,7 +240,7 @@ export default function SellerOrderList() {
                     {rows.shippingFees.toLocaleString()}원
                   </TableCell>
                   <TableCell align="center">
-                    {getOrderStateLabel(rows._id) || '주문없음'}
+                    {getOrderStateLabel(rows._id) || ''}
                   </TableCell>
                   <TableCell align="center">
                     <ToggleButton

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -196,7 +196,7 @@ export default function SellerOrderList() {
 
                   <TableCell align="center">
                     <img
-                      src={`${rows.products[0].image}`}
+                      src={`${rows.products[0].image.path}`}
                       alt="main-Image"
                       style={{
                         width: '80px',

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -50,15 +50,14 @@ export default function SellerOrderList() {
   }
   const fetchSellerProduct = async () => {
     try {
-      const response = await api.getProductList();
-      const getMatchItem = response.data.item.filter(
-        (product: IProduct) => product.seller_id === Number(_id),
-      );
+      const response = await api.getOrderState();
+      const getMatchItem = response.data.item;
       setProductList(getMatchItem);
     } catch (error) {
       console.log('판매 상품 조회 실패', error);
     }
   };
+  console.log('판매상품 리스트', productList);
 
   useEffect(() => {
     const getOrderState = async () => {
@@ -66,9 +65,9 @@ export default function SellerOrderList() {
         const response = await api.getOrderState();
         const orderState = response.data.item;
         const orderStatesMap: Record<string, string> = {};
-
         orderState.forEach((orderItem: IOrderItem) => {
           orderItem.products.forEach((product) => {
+            console.log('orderItem', orderItem.state);
             orderStatesMap[product.name] = orderItem.state;
           });
         });
@@ -175,12 +174,11 @@ export default function SellerOrderList() {
                   등록일자
                   <br /> (등록번호)
                 </TableCell>
-                <TableCell align="center">카테고리</TableCell>
+
                 <TableCell align="center">이미지</TableCell>
                 <TableCell align="center">상품명</TableCell>
                 <TableCell align="center">품질</TableCell>
                 <TableCell align="center">가격</TableCell>
-                <TableCell align="center">배송료</TableCell>
                 <TableCell align="center">주문상태</TableCell>
                 <TableCell align="center">공개여부</TableCell>
                 <TableCell align="center"></TableCell>
@@ -195,21 +193,10 @@ export default function SellerOrderList() {
                     </Typography>
                     ({rows._id})
                   </TableCell>
-                  <TableCell align="center">
-                    {CATEGORY.depth2
-                      .filter(
-                        (category) =>
-                          category.dbCode === rows.extra.category[1],
-                      )
-                      .map((categoryName) => (
-                        <Typography key={categoryName.id} variant="body2">
-                          {categoryName.name}
-                        </Typography>
-                      ))}
-                  </TableCell>
+
                   <TableCell align="center">
                     <img
-                      src={`${rows.mainImages[0].path}`}
+                      src={`${rows.products[0].image}`}
                       alt="main-Image"
                       style={{
                         width: '80px',
@@ -221,23 +208,22 @@ export default function SellerOrderList() {
                   </TableCell>
                   <TableCell align="center">
                     <Link to={`http://localhost:5173/product/${rows._id}`}>
-                      {rows.name}
+                      {rows.products[0].name}
                     </Link>
                   </TableCell>
                   <TableCell align="center">
-                    {rows.extra.sort
+                    {rows.products[0].quantity.sort
                       ? QUALITY.find(
-                          (quality) => quality.value === rows.extra.sort,
+                          (quality) =>
+                            quality.value === rows.products[0].quantity.sort,
                         )?.name
                       : QUALITY.find(
-                          (quality) => quality.value === rows.quantity,
+                          (quality) =>
+                            quality.value === rows.products[0].quantity,
                         )?.name || 'Unknown Quality'}
                   </TableCell>
                   <TableCell align="center">
-                    {rows.price.toLocaleString()}원
-                  </TableCell>
-                  <TableCell align="center">
-                    {rows.shippingFees.toLocaleString()}원
+                    {rows.products[0].price.toLocaleString()}원
                   </TableCell>
                   <TableCell align="center">
                     {getOrderStateLabel(rows._id) || ''}

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 
 import {
@@ -26,7 +26,6 @@ import { CATEGORY, QUALITY } from '../../constants/index';
 
 export default function SellerOrderList() {
   const _id = localStorage.getItem('_id');
-  const { id } = useParams();
 
   const [productList, setProductList] = useState<IProduct[]>([]);
   const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -1,9 +1,52 @@
-import * as React from 'react';
-import { Link, Outlet } from 'react-router-dom';
-import { Button } from '@mui/material';
+import { Link, useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
-const _id = localStorage.getItem('_id');
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Paper,
+  ToggleButton,
+  Typography,
+  Box,
+  Button,
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl,
+} from '@mui/material';
+
+import { api } from '../../api/api';
+import { IProduct } from '../../type';
+import { CATEGORY } from '../../constants/index';
+
 export default function SellerOrderList() {
+  const _id = localStorage.getItem('_id');
+  const { id } = useParams();
+
+  const [productList, setProductList] = useState<IProduct[]>([]);
+  const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);
+  const [sortOrder, setSortOrder] = useState('최신순');
+  const [isShow, setIsShow] = useState(false);
+
+  useEffect(() => {
+    fetchSellerProduct();
+  }, []);
+  const fetchSellerProduct = async () => {
+    try {
+      const response = await api.getSellerProductInfo();
+      console.log('상품데이터 조회', response);
+      const getMatchItem = response.data.item.filter(
+        (id: IProduct) => id.seller_id === Number(_id),
+      );
+      setProductList(getMatchItem);
+    } catch (error) {
+      console.log('판매 상품 조회 실패', error);
+    }
+  };
   return (
     <>
       <Link to={`/user/${_id}/product-create`}>

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -16,7 +16,9 @@ import {
   MenuItem,
   InputLabel,
   FormControl,
+  ToggleButton,
 } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
 
 import { api } from '../../api/api';
 import { IProduct } from '../../type';
@@ -29,6 +31,7 @@ export default function SellerOrderList() {
   const [productList, setProductList] = useState<IProduct[]>([]);
   const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);
   const [sortOrder, setSortOrder] = useState('최신순');
+  const [isShow, setIsShow] = useState(false);
 
   useEffect(() => {
     fetchSellerProduct();
@@ -43,8 +46,7 @@ export default function SellerOrderList() {
   }
   const fetchSellerProduct = async () => {
     try {
-      const response = await api.getSellerProductInfo();
-      console.log('상품데이터 조회', response);
+      const response = await api.getProductList();
       const getMatchItem = response.data.item.filter(
         (product: IProduct) => product.seller_id === Number(_id),
       );
@@ -53,7 +55,6 @@ export default function SellerOrderList() {
       console.log('판매 상품 조회 실패', error);
     }
   };
-
   useEffect(() => {
     let sorted = [...productList];
     switch (sortOrder) {
@@ -137,6 +138,8 @@ export default function SellerOrderList() {
                 <TableCell align="center">상품명</TableCell>
                 <TableCell align="center">품질</TableCell>
                 <TableCell align="center">가격</TableCell>
+                <TableCell align="center">배송료</TableCell>
+                <TableCell align="center">공개여부</TableCell>
                 <TableCell align="center"></TableCell>
               </TableRow>
             </TableHead>
@@ -179,13 +182,32 @@ export default function SellerOrderList() {
                     </Link>
                   </TableCell>
                   <TableCell align="center">
-                    {QUALITY.find((quality) => quality.value === rows.quantity)
-                      ?.name || '상급'}
+                    {rows.extra.sort
+                      ? QUALITY.find(
+                          (quality) => quality.value === rows.extra.sort,
+                        )?.name
+                      : QUALITY.find(
+                          (quality) => quality.value === rows.quantity,
+                        )?.name || 'Unknown Quality'}
                   </TableCell>
                   <TableCell align="center">
                     {rows.price.toLocaleString()}원
                   </TableCell>
-
+                  <TableCell align="center">
+                    {rows.shippingFees.toLocaleString()}원
+                  </TableCell>
+                  <TableCell align="center">
+                    <ToggleButton
+                      value="check"
+                      selected={isShow}
+                      size={'small'}
+                      onChange={() => {
+                        setIsShow(!rows.show);
+                      }}
+                    >
+                      <CheckIcon />
+                    </ToggleButton>
+                  </TableCell>
                   <TableCell align="center">
                     <Box
                       sx={{

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -18,10 +18,11 @@ import {
   InputLabel,
   FormControl,
 } from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
 
 import { api } from '../../api/api';
 import { IProduct } from '../../type';
-import { CATEGORY } from '../../constants/index';
+import { CATEGORY, QUALITY } from '../../constants/index';
 
 export default function SellerOrderList() {
   const _id = localStorage.getItem('_id');
@@ -35,8 +36,17 @@ export default function SellerOrderList() {
   useEffect(() => {
     fetchSellerProduct();
   }, []);
+
+  function formatDate(dateString: string) {
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(new Date(dateString));
+  }
   const fetchSellerProduct = async () => {
     try {
+      console.log('판매자 id', _id);
       const response = await api.getSellerProductInfo();
       console.log('상품데이터 조회', response);
       const getMatchItem = response.data.item.filter(
@@ -47,11 +57,146 @@ export default function SellerOrderList() {
       console.log('판매 상품 조회 실패', error);
     }
   };
+
+  useEffect(() => {
+    let sorted = [...productList];
+    switch (sortOrder) {
+      case '최신순':
+        sorted.sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+        break;
+      case '오래된순':
+        sorted.sort(
+          (a, b) =>
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        );
+        break;
+      case '가-하':
+        sorted.sort((a, b) => a.price - b.price);
+        break;
+      case '하-가':
+        sorted.sort((a, b) => b.price - a.price);
+        break;
+      default:
+        break;
+    }
+    setSortedProductList(sorted);
+  }, [productList, sortOrder]);
+
+  if (productList.length === 0) {
+    return (
+      <>
+        <Typography variant="h3" sx={{ marginBottom: '1rem' }}>
+          등록된 물품이 없습니다.
+        </Typography>
+        <Link to={`/user/${_id}/product-create`}>
+          <Button type="button" variant="contained" size="large">
+            물품 등록하러 가기
+          </Button>
+        </Link>
+      </>
+    );
+  }
+
   return (
     <>
       <Link to={`/user/${_id}/product-create`}>
         <Button variant="contained">등록하기</Button>
       </Link>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: 2,
+        }}
+      >
+        <FormControl>
+          <InputLabel id="sort-label">정렬</InputLabel>
+          <Select
+            labelId="sort-label"
+            id="sort-select"
+            value={sortOrder}
+            size="small"
+            onChange={(e) => setSortOrder(e.target.value)}
+          >
+            <MenuItem value="최신순">최신순</MenuItem>
+            <MenuItem value="오래된순">오래된순</MenuItem>
+            <MenuItem value="가-하">가격: 낮은 순</MenuItem>
+            <MenuItem value="하-가">가격: 높은 순</MenuItem>
+          </Select>
+        </FormControl>
+        <TableContainer component={Paper}>
+          <Table aria-label="구매내역">
+            <TableHead>
+              <TableRow>
+                <TableCell align="center">
+                  등록일자
+                  <br /> (등록번호)
+                </TableCell>
+                <TableCell align="center">카테고리</TableCell>
+                <TableCell align="center">이미지</TableCell>
+                <TableCell align="center">상품명</TableCell>
+                <TableCell align="center">품질</TableCell>
+                <TableCell align="center">가격</TableCell>
+                <TableCell align="center"></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {sortedProductList.map((rows) => (
+                <TableRow key={rows._id}>
+                  <TableCell align="center">
+                    <Typography variant="body2" color="text.secondary">
+                      {formatDate(rows.createdAt)}
+                    </Typography>
+                    ({rows._id})
+                  </TableCell>
+                  <TableCell align="center">
+                    {CATEGORY.depth2
+                      .filter(
+                        (category) =>
+                          category.dbCode === rows.extra.category[1],
+                      )
+                      .map((categoryName) => (
+                        <Typography key={categoryName.id} variant="body2">
+                          {categoryName.name}
+                        </Typography>
+                      ))}
+                  </TableCell>
+                  <TableCell align="center">
+                    <img
+                      src={`${rows.mainImages[0]}`}
+                      alt="main-Image"
+                      style={{ width: '80px' }}
+                    />
+                  </TableCell>
+                  <TableCell align="center">{rows.name}</TableCell>
+                  <TableCell align="center">
+                    {QUALITY.find((quality) => quality.value === rows.quantity)
+                      ?.name || '상급'}
+                  </TableCell>
+                  <TableCell align="center">
+                    {rows.price.toLocaleString()}원
+                  </TableCell>
+
+                  <TableCell align="center">
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: 1,
+                      }}
+                    ></Box>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
     </>
   );
 }

--- a/src/components/seller/SellerOrderList.tsx
+++ b/src/components/seller/SellerOrderList.tsx
@@ -9,7 +9,6 @@ import {
   TableRow,
   TableCell,
   Paper,
-  ToggleButton,
   Typography,
   Box,
   Button,
@@ -18,7 +17,6 @@ import {
   InputLabel,
   FormControl,
 } from '@mui/material';
-import CheckIcon from '@mui/icons-material/Check';
 
 import { api } from '../../api/api';
 import { IProduct } from '../../type';
@@ -31,7 +29,6 @@ export default function SellerOrderList() {
   const [productList, setProductList] = useState<IProduct[]>([]);
   const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);
   const [sortOrder, setSortOrder] = useState('최신순');
-  const [isShow, setIsShow] = useState(false);
 
   useEffect(() => {
     fetchSellerProduct();
@@ -46,11 +43,10 @@ export default function SellerOrderList() {
   }
   const fetchSellerProduct = async () => {
     try {
-      console.log('판매자 id', _id);
       const response = await api.getSellerProductInfo();
       console.log('상품데이터 조회', response);
       const getMatchItem = response.data.item.filter(
-        (id: IProduct) => id.seller_id === Number(_id),
+        (product: IProduct) => product.seller_id === Number(_id),
       );
       setProductList(getMatchItem);
     } catch (error) {
@@ -167,12 +163,21 @@ export default function SellerOrderList() {
                   </TableCell>
                   <TableCell align="center">
                     <img
-                      src={`${rows.mainImages[0]}`}
+                      src={`${rows.mainImages[0].path}`}
                       alt="main-Image"
-                      style={{ width: '80px' }}
+                      style={{
+                        width: '80px',
+                        height: '80px',
+                        objectFit: 'cover',
+                        borderRadius: '5px',
+                      }}
                     />
                   </TableCell>
-                  <TableCell align="center">{rows.name}</TableCell>
+                  <TableCell align="center">
+                    <Link to={`http://localhost:5173/product/${rows._id}`}>
+                      {rows.name}
+                    </Link>
+                  </TableCell>
                   <TableCell align="center">
                     {QUALITY.find((quality) => quality.value === rows.quantity)
                       ?.name || '상급'}
@@ -190,6 +195,16 @@ export default function SellerOrderList() {
                         gap: 1,
                       }}
                     ></Box>
+                  </TableCell>
+                  <TableCell align="center">
+                    <Link
+                      to={`/user/${rows._id}/product-update`}
+                      state={{ productId: `${rows._id}` }}
+                    >
+                      <Button type="button" variant="contained">
+                        수정하기
+                      </Button>
+                    </Link>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/components/seller/SellerOrderManager.tsx
+++ b/src/components/seller/SellerOrderManager.tsx
@@ -20,6 +20,8 @@ import { api } from '../../api/api';
 import { IProduct, IOrderItem } from '../../type';
 import { CATEGORY, QUALITY, ORDER_STATE } from '../../constants/index';
 import { Link } from 'react-router-dom';
+import formatDate from '../../lib/formatDate';
+import { localURL } from '../../lib/localURL';
 
 export default function SellerOrderManager() {
   const _id = localStorage.getItem('_id');
@@ -27,15 +29,6 @@ export default function SellerOrderManager() {
   const [sortedProductList, setSortedProductList] = useState<IProduct[]>([]);
   const [sortOrder, setSortOrder] = useState('최신순');
   const [orderList, setOrderList] = useState<IOrderItem[]>([]);
-
-  // 날짜 변환 함수
-  function formatDate(dateString: string) {
-    return new Intl.DateTimeFormat('ko-KR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    }).format(new Date(dateString));
-  }
 
   useEffect(() => {
     const fetchSellerProductData = async () => {
@@ -173,7 +166,7 @@ export default function SellerOrderManager() {
                   <TableCell align="center">
                     <img
                       src={`${rows.mainImages[0].path}`}
-                      alt="main-Image"
+                      alt={`${rows.mainImages[0].id}`}
                       style={{
                         width: '80px',
                         height: '80px',
@@ -183,7 +176,7 @@ export default function SellerOrderManager() {
                     />
                   </TableCell>
                   <TableCell align="center">
-                    <Link to={`http://localhost:5173/product/${rows._id}`}>
+                    <Link to={`${localURL}/product/${rows._id}`}>
                       {rows.name}
                     </Link>
                   </TableCell>

--- a/src/components/seller/SellerOrderManager.tsx
+++ b/src/components/seller/SellerOrderManager.tsx
@@ -176,9 +176,7 @@ export default function SellerOrderManager() {
                     />
                   </TableCell>
                   <TableCell align="center">
-                    <Link to={`${localURL}/product/${rows._id}`}>
-                      {rows.name}
-                    </Link>
+                    <Link to={`/product/${rows._id}`}>{rows.name}</Link>
                   </TableCell>
                   <TableCell align="center">
                     {rows.price.toLocaleString()}원

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,7 +42,7 @@ export const DASHBOARD_MENU = {
     },
     {
       id: 3,
-      title: '주문 상태 관리',
+      title: '주문 관리',
       url: `/user/${_id}/seller-order-manager`,
     },
   ],

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -33,7 +33,7 @@ export const DASHBOARD_MENU = {
     {
       id: 1,
       title: '판매 상품 관리',
-      url: `/user/${_id}/seller-orderlist`,
+      url: `/user/${_id}/product-manager`,
     },
     {
       id: 2,
@@ -43,7 +43,7 @@ export const DASHBOARD_MENU = {
     {
       id: 3,
       title: '주문 상태 관리',
-      url: `/user/${_id}/product-manager`,
+      url: `/user/${_id}/seller-order-manager`,
     },
   ],
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -32,7 +32,7 @@ export const DASHBOARD_MENU = {
   seller: [
     {
       id: 1,
-      title: '판매자 대시보드',
+      title: '판매 상품 관리',
       url: `/user/${_id}/seller-orderlist`,
     },
     {
@@ -42,7 +42,7 @@ export const DASHBOARD_MENU = {
     },
     {
       id: 3,
-      title: '상품 관리',
+      title: '주문 상태 관리',
       url: `/user/${_id}/product-manager`,
     },
   ],

--- a/src/lib/localURL.ts
+++ b/src/lib/localURL.ts
@@ -1,0 +1,1 @@
+export const localURL = 'http://localhost:5173';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,8 +14,8 @@ import { BuyerHome } from './components/buyer/BuyerHome.tsx';
 import ProductCreate from './components/seller/ProductCreate.tsx';
 import ProductUpdate from './components/seller/ProductUpdate.tsx';
 import SellerInfo from './components/seller/SellerInfo.tsx';
-import SellerOrderList from './components/seller/SellerOrderList.tsx';
 import ProductManager from './components/seller/ProductManager.tsx';
+import SellerOrderManager from './components/seller/SellerOrderManager.tsx';
 import SignInPage from './pages/user/SignIn.tsx';
 import SignUpPage from './pages/user/SignUp.tsx';
 import { CategoryList } from './pages/product/CategoryList.tsx';
@@ -59,8 +59,8 @@ const router = createBrowserRouter([
         element: <BuyerFavorite />,
       },
       {
-        path: '/user/:id/product-manager',
-        element: <ProductManager />,
+        path: '/user/:id/seller-order-manager',
+        element: <SellerOrderManager />,
       },
       {
         path: '/user/:id/product-create',
@@ -75,8 +75,8 @@ const router = createBrowserRouter([
         element: <SellerInfo />,
       },
       {
-        path: '/user/:id/seller-orderlist',
-        element: <SellerOrderList />,
+        path: '/user/:id/product-manager',
+        element: <ProductManager />,
       },
       {
         path: '/user/:id/recently-viewed-items',


### PR DESCRIPTION
## 🧾 관련 이슈
close : 
#76 

## 🔎 구현한 내용
판매자 상품 리스트 조회
판매자용 api로 변경


## 📸 스크린샷(선택사항)
![image](https://github.com/PhoenixFE/orum-market-front/assets/121228672/c3497153-bbbb-49e2-b650-3aae2687fc73)





## 🙌 리뷰어에게
이미지가 초기데이터여서 연결이 안됩니다.


