### PR TITLE
Design: 대시보드 사이드바 스타일 및 페이지별 제목 통일

### DIFF
--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -21,6 +21,9 @@ export default function BuyerFavorite() {
 
   return (
     <>
+      <Typography variant="h5" fontWeight={700}>
+        찜한 상품
+      </Typography>
       <BookmarkListTable myBookmarkList={bookmarkList} />
     </>
   );

--- a/src/components/buyer/BuyerHome.tsx
+++ b/src/components/buyer/BuyerHome.tsx
@@ -14,7 +14,9 @@ export const BuyerHome = () => {
 
   return (
     <>
-      <h1>구매자 대시보드</h1>
+      <Typography variant="h5" fontWeight={700}>
+        구매자 대시보드
+      </Typography>
       <Box
         sx={{
           display: 'flex',
@@ -22,7 +24,9 @@ export const BuyerHome = () => {
           alignItems: 'end',
         }}
       >
-        <Typography variant="h5">내 주문 내역</Typography>
+        <Typography variant="h6" fontWeight={600}>
+          내 주문 내역
+        </Typography>
         <Link to={`/user/${id}/buyer-orderlist`}>
           <Button type="button">전체보기</Button>
         </Link>
@@ -36,7 +40,9 @@ export const BuyerHome = () => {
           alignItems: 'end',
         }}
       >
-        <Typography variant="h5">찜한 상품</Typography>
+        <Typography variant="h6" fontWeight={600}>
+          찜한 상품
+        </Typography>
         <Link to={`/user/${id}/buyer-favorite`}>
           <Button type="button">전체보기</Button>
         </Link>

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -216,7 +216,9 @@ export default function BuyerInfo() {
     <Container>
       {userInfo && !isCreateAddress && !isEditAddress && (
         <>
-          <Typography variant="h4">내 정보 수정</Typography>
+          <Typography variant="h5" fontWeight={700}>
+            내 정보 수정
+          </Typography>
           <form onSubmit={handleUpdateUserInfo}>
             <FormLabel>이메일</FormLabel>
             <TextField

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -24,7 +24,9 @@ export default function BuyerOrdeList() {
 
   return (
     <>
-      <Typography variant="h5">내 주문 내역</Typography>
+      <Typography variant="h5" fontWeight={700}>
+        내 주문 내역
+      </Typography>
       <OrderListTable orderList={orderList} />
     </>
   );

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -31,6 +31,9 @@ export default function BuyerRecentlyView() {
   return (
     <>
       <Container>
+        <Typography variant="h5" fontWeight={700}>
+          최근 본 상품
+        </Typography>
         {viewItems.map((product) => (
           <StyledCard key={product._id}>
             <CardActionArea component={Link} to={`/product/${product._id}`}>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,7 +14,7 @@ export const DASHBOARD_MENU = {
     },
     {
       id: 3,
-      title: '주문 내역',
+      title: '내 주문 내역',
       url: `/user/${_id}/buyer-orderlist`,
     },
     {

--- a/src/pages/user/Dashboard.tsx
+++ b/src/pages/user/Dashboard.tsx
@@ -17,6 +17,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { Link, Outlet } from 'react-router-dom';
 import { DASHBOARD_MENU } from '../../constants';
+import { Grid } from '@mui/material';
 
 const drawerWidth = 240;
 
@@ -27,13 +28,27 @@ interface Props {
 export default function Dashboard(props: Props) {
   const { window } = props;
   const [mobileOpen, setMobileOpen] = React.useState(false);
+  const [selectedBuyerMenu, setSelectedBuyerMenu] = React.useState(
+    DASHBOARD_MENU.buyer[0].title,
+  );
+  const [selectSellerMenu, setSelectSellerMenu] = React.useState('');
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
   };
 
+  const handleSelectBuyerMenu = (itemBuyerTitle: string) => {
+    setSelectedBuyerMenu(itemBuyerTitle);
+    setSelectSellerMenu('');
+  };
+
+  const handleSelectSellerMenu = (itemSellerTitle: string) => {
+    setSelectSellerMenu(itemSellerTitle);
+    setSelectedBuyerMenu('');
+  };
+
   const drawer = (
-    <div>
+    <Grid item xs={3}>
       <Toolbar />
       <Divider />
       <List>
@@ -43,8 +58,20 @@ export default function Dashboard(props: Props) {
               <ListItemIcon>
                 {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
               </ListItemIcon>
-              <Link to={items.url}>
-                <ListItemText primary={items.title} />
+              <Link
+                to={items.url}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                <ListItemText
+                  primary={items.title}
+                  primaryTypographyProps={{
+                    fontSize: '16',
+                    fontWeight:
+                      selectedBuyerMenu === items.title ? 'bold' : 'medium',
+                    letterSpacing: 0,
+                  }}
+                  onClick={() => handleSelectBuyerMenu(items.title)}
+                />
               </Link>
             </ListItemButton>
           </ListItem>
@@ -58,14 +85,26 @@ export default function Dashboard(props: Props) {
               <ListItemIcon>
                 {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
               </ListItemIcon>
-              <Link to={items.url}>
-                <ListItemText primary={items.title} />
+              <Link
+                to={items.url}
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                <ListItemText
+                  primary={items.title}
+                  primaryTypographyProps={{
+                    fontSize: '16',
+                    fontWeight:
+                      selectSellerMenu === items.title ? 'bold' : 'medium',
+                    letterSpacing: 0,
+                  }}
+                  onClick={() => handleSelectSellerMenu(items.title)}
+                />
               </Link>
             </ListItemButton>
           </ListItem>
         ))}
       </List>
-    </div>
+    </Grid>
   );
 
   // Remove this const when copying and pasting into your project.
@@ -76,10 +115,13 @@ export default function Dashboard(props: Props) {
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
       <AppBar
+        component="nav"
         position="fixed"
+        color="inherit"
         sx={{
-          width: { sm: `calc(100% - ${drawerWidth}px)` },
-          ml: { sm: `${drawerWidth}px` },
+          boxShadow: 'none',
+          borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+          zIndex: (theme) => theme.zIndex.drawer + 1,
         }}
       >
         <Toolbar>
@@ -92,9 +134,14 @@ export default function Dashboard(props: Props) {
           >
             <MenuIcon />
           </IconButton>
-          <Link to="/">
-            <Typography variant="h6" noWrap component="div">
-              Orum Market
+
+          <Link to="/" style={{ alignItems: 'center' }}>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              <img
+                src="../../assets/logo.png"
+                alt="ORUM"
+                style={{ width: '100px', height: 'auto' }}
+              />
             </Typography>
           </Link>
         </Toolbar>
@@ -102,7 +149,7 @@ export default function Dashboard(props: Props) {
       <Box
         component="nav"
         sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
-        aria-label="mailbox folders"
+        aria-label="dashboard"
       >
         {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
         <Drawer

--- a/src/pages/user/Dashboard.tsx
+++ b/src/pages/user/Dashboard.tsx
@@ -52,6 +52,11 @@ export default function Dashboard(props: Props) {
       <Toolbar />
       <Divider />
       <List>
+        <Box sx={{ padding: '20px 16px 8px' }}>
+          <Typography variant="h6" fontWeight={700}>
+            구매자
+          </Typography>
+        </Box>
         {DASHBOARD_MENU.buyer.map((items) => (
           <ListItem key={items.id} disablePadding>
             <ListItemButton>
@@ -79,6 +84,11 @@ export default function Dashboard(props: Props) {
       </List>
       <Divider />
       <List>
+        <Box sx={{ padding: '20px 16px 8px' }}>
+          <Typography variant="h6" fontWeight={700}>
+            판매자
+          </Typography>
+        </Box>
         {DASHBOARD_MENU.seller.map((items) => (
           <ListItem key={items.id} disablePadding>
             <ListItemButton>
@@ -188,7 +198,8 @@ export default function Dashboard(props: Props) {
         component="main"
         sx={{
           flexGrow: 1,
-          p: 3,
+          paddingX: 4,
+          paddingY: 3.7,
           width: { sm: `calc(100% - ${drawerWidth}px)` },
         }}
       >


### PR DESCRIPTION
## 🧾 관련 이슈
close : #90 


## 🔎 구현한 내용
- 대시보드 사이드바 active 효과
- 대시보드 메뉴와 각 페이지별 제목 통일


## 📸 스크린샷(선택사항)
![s](https://github.com/PhoenixFE/orum-market-front/assets/104605709/d8e258bd-0462-43a2-9cf1-4483b0feb3de)
![ㅇㄴ](https://github.com/PhoenixFE/orum-market-front/assets/104605709/9b6e6b4a-895b-4b9c-a9bf-083e8b7892db)


## 🙌 리뷰어에게
- 대시보드 App bar도 메인과 통일성을 주는게 좋을 것 같아 메인쪽 디자인으로 로고와 스타일만 적용해두었습니다. (단, 메인과 달리 화면이 좁아지면 사이드바가 drawer menu로 변경되는건 기존과 동일합니다.)
- 사이드바의 경우 하나의 컴포넌트 안에서 작업이 가능해서 전체적으로 변경했으며, 각 페이지별 제목 스타일은 제가 작업하고 있는 구매자쪽만 먼저 수정했습니다.
- 우선은 구매자, 판매자를 전체 사이드바로 보고 구매자쪽 메뉴가 선택되면 판매자쪽 메뉴는 미선택으로 구현해놨습니다.(반대의 경우도 동일)
- 전체 구조(패딩, 마진) 스타일링은 새로운 이슈 파서 진행할 예정입니다.

