### PR TITLE
Design/Feat: 북마크(찜한 상품) 페이지 화면 작업 및 대시보드 마진/패딩 구조 통일

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/uuid": "^9.0.7",
         "axios": "^1.6.2",
         "framer-motion": "^10.16.15",
+        "lodash": "^4.17.21",
         "mem": "^10.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -28,6 +29,7 @@
         "zustand": "^4.4.6"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.202",
         "@types/node": "^20.9.4",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
@@ -1719,6 +1721,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -4131,6 +4139,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "@mui/joy": "^5.0.0-beta.17",
     "@mui/material": "^5.14.18",
     "@mui/styled-engine-sc": "^6.0.0-alpha.6",
-    "@types/uuid": "^9.0.7",
     "@toast-ui/react-editor": "^3.2.3",
+    "@types/uuid": "^9.0.7",
     "axios": "^1.6.2",
     "framer-motion": "^10.16.15",
+    "lodash": "^4.17.21",
     "mem": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -30,6 +31,7 @@
     "zustand": "^4.4.6"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.202",
     "@types/node": "^20.9.4",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/src/components/address/AddressForm.tsx
+++ b/src/components/address/AddressForm.tsx
@@ -10,9 +10,10 @@ export default function AddressForm({
 }) {
   return (
     <>
-      <Typography variant="h6" fontWeight={700} mb={3}>
+      <Typography variant="h5" fontWeight={700} marginBottom={1}>
         {title}
       </Typography>
+
       <form onSubmit={(e) => submit(e)}>
         <FormLabel>배송지명*</FormLabel>
         <TextField
@@ -23,7 +24,7 @@ export default function AddressForm({
           size="small"
           fullWidth
           required
-          sx={{ marginBottom: '1rem' }}
+          sx={{ marginBottom: '10px' }}
           onChange={func}
         />
         <FormLabel>수령인*</FormLabel>
@@ -35,7 +36,7 @@ export default function AddressForm({
           size="small"
           fullWidth
           required
-          sx={{ marginBottom: '1rem' }}
+          sx={{ marginBottom: '10px' }}
           onChange={func}
         />
         <FormLabel>연락처*</FormLabel>
@@ -47,7 +48,7 @@ export default function AddressForm({
           size="small"
           fullWidth
           required
-          sx={{ marginBottom: '1rem' }}
+          sx={{ marginBottom: '10px' }}
           onChange={func}
         />
         <FormLabel>배송 주소*</FormLabel>
@@ -59,7 +60,7 @@ export default function AddressForm({
           size="small"
           fullWidth
           required
-          sx={{ marginBottom: '0.4rem' }}
+          sx={{ marginBottom: '6px' }}
           onChange={func}
         />
         <TextField
@@ -70,10 +71,9 @@ export default function AddressForm({
           size="small"
           fullWidth
           required
-          sx={{ marginBottom: '1rem' }}
           onChange={func}
         />
-        <Box sx={{ display: 'flex', flexDirection: 'row' }} gap={3} my={3}>
+        <Box sx={{ display: 'flex', flexDirection: 'row' }} gap={1.2} my={1.6}>
           <Button type="submit" size="large" variant="contained" fullWidth>
             저장
           </Button>

--- a/src/components/buyer/BookmarkListTable.tsx
+++ b/src/components/buyer/BookmarkListTable.tsx
@@ -9,15 +9,29 @@ import {
   Button,
 } from '@mui/material';
 import { Link } from 'react-router-dom';
+import { Close } from '@mui/icons-material';
 
 import deleteBookmark from '../../lib/deleteBookmark';
-import { Close } from '@mui/icons-material';
+import { api } from '../../api/api';
+import useAddToCart from '../../hooks/useAddToCart';
 
 export default function BookmarkListTable({ myBookmarkList }) {
   // 아이템 사이즈를 계산하는 함수
   const getItemSize = () => {
     return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
   };
+
+  const handleSearchProduct = async (productId) => {
+    console.log(productId);
+    const response = await api.getProductList();
+    const product = response.data.item.find((item) => item._id === productId);
+    console.log(product);
+
+    handleAddToCart(product);
+  };
+
+  const handleAddToCart = useAddToCart();
+
   return (
     <>
       {myBookmarkList
@@ -40,7 +54,11 @@ export default function BookmarkListTable({ myBookmarkList }) {
                 </ProductDetails>
               </CardActionArea>
               <ProductActions>
-                <Button variant="outlined" style={{ flexGrow: '1' }}>
+                <Button
+                  variant="outlined"
+                  style={{ flexGrow: '1' }}
+                  onClick={() => handleSearchProduct(bookmark.product_id)}
+                >
                   장바구니 담기
                 </Button>
                 <Button

--- a/src/components/buyer/BookmarkListTable.tsx
+++ b/src/components/buyer/BookmarkListTable.tsx
@@ -1,49 +1,62 @@
 import {
   CardActionArea,
-  Container,
   Typography,
-  IconButton,
   styled,
   Card,
   CardMedia,
   Box,
+  Grid,
+  Button,
 } from '@mui/material';
-import FavoriteIcon from '@mui/icons-material/Favorite';
 import { Link } from 'react-router-dom';
 
 import deleteBookmark from '../../lib/deleteBookmark';
+import { Close } from '@mui/icons-material';
 
 export default function BookmarkListTable({ myBookmarkList }) {
+  // 아이템 사이즈를 계산하는 함수
+  const getItemSize = () => {
+    return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
+  };
   return (
-    <Container>
+    <>
       {myBookmarkList
         .map((bookmark) => (
-          <StyledCard key={bookmark._id}>
-            <CardActionArea
-              component={Link}
-              to={`/product/${bookmark.product_id}`}
-            >
-              <ProductImage
-                image={bookmark.product.image.path}
-                title={bookmark.product.name}
-              />
-              <ProductDetails>
-                <Typography variant="h6">{bookmark.product.name}</Typography>
-                <Typography variant="h6" color="inherit" fontWeight={700}>
-                  {bookmark.product.price.toLocaleString()} 원
-                </Typography>
-              </ProductDetails>
-            </CardActionArea>
-            <ProductActions>
-              <IconButton onClick={() => deleteBookmark(bookmark._id)}>
-                <FavoriteIcon />
-              </IconButton>
-            </ProductActions>
-          </StyledCard>
+          <Grid item {...getItemSize()} key={bookmark._id} marginTop={3}>
+            <StyledCard>
+              <CardActionArea
+                component={Link}
+                to={`/product/${bookmark.product_id}`}
+              >
+                <ProductImage
+                  image={bookmark.product.image.path}
+                  title={bookmark.product.name}
+                />
+                <ProductDetails>
+                  <Typography variant="h6">{bookmark.product.name}</Typography>
+                  <Typography variant="h6" color="inherit" fontWeight={700}>
+                    {bookmark.product.price.toLocaleString()} 원
+                  </Typography>
+                </ProductDetails>
+              </CardActionArea>
+              <ProductActions>
+                <Button variant="outlined" style={{ flexGrow: '1' }}>
+                  장바구니 담기
+                </Button>
+                <Button
+                  variant="outlined"
+                  onClick={() => deleteBookmark(bookmark._id)}
+                >
+                  <Close />
+                  삭제
+                </Button>
+              </ProductActions>
+            </StyledCard>
+          </Grid>
         ))
         .sort()
         .reverse()}
-    </Container>
+    </>
   );
 }
 
@@ -53,6 +66,7 @@ const StyledCard = styled(Card)({
   position: 'relative',
   boxShadow: 'none',
   borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+  paddingBottom: '6px',
 });
 
 const ProductImage = styled(CardMedia)({
@@ -65,12 +79,14 @@ const ProductDetails = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'start',
-  padding: '16px',
+  padding: '12px 4px 6px',
 });
 
 const ProductActions = styled(Box)({
   display: 'flex',
-  justifyContent: 'flex-end',
+  justifyContent: 'space-between',
+  gap: '6px',
   alignItems: 'center',
   padding: '4px',
+  flexWrap: 'wrap',
 });

--- a/src/components/buyer/BookmarkListTable.tsx
+++ b/src/components/buyer/BookmarkListTable.tsx
@@ -18,7 +18,7 @@ import useAddToCart from '../../hooks/useAddToCart';
 export default function BookmarkListTable({ myBookmarkList }) {
   // 아이템 사이즈를 계산하는 함수
   const getItemSize = () => {
-    return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
+    return { xs: 12, sm: 6, md: 4, lg: 3, xl: 3 };
   };
 
   const handleSearchProduct = async (productId) => {

--- a/src/components/buyer/BookmarkListTable.tsx
+++ b/src/components/buyer/BookmarkListTable.tsx
@@ -22,10 +22,8 @@ export default function BookmarkListTable({ myBookmarkList }) {
   };
 
   const handleSearchProduct = async (productId) => {
-    console.log(productId);
     const response = await api.getProductList();
     const product = response.data.item.find((item) => item._id === productId);
-    console.log(product);
 
     handleAddToCart(product);
   };

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from '@mui/material';
+import { Button, Grid, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 import BookmarkListTable from './BookmarkListTable';
 import useGetBookmark from '../../hooks/useGetBookmark';
@@ -9,7 +9,10 @@ export default function BuyerFavorite() {
   if (!bookmarkList || bookmarkList?.length === 0) {
     return (
       <>
-        <Typography variant="h6">북마크된 상품이 없습니다.</Typography>
+        <Typography variant="h5" fontWeight={700}>
+          찜한 상품 ({bookmarkList.length})
+        </Typography>
+        <Typography variant="h6">찜한 상품 목록이 없습니다.</Typography>
         <Link to={`/`}>
           <Button type="button" variant="outlined" size="medium">
             상품 보러 가기
@@ -22,9 +25,11 @@ export default function BuyerFavorite() {
   return (
     <>
       <Typography variant="h5" fontWeight={700}>
-        찜한 상품
+        찜한 상품 ({bookmarkList.length})
       </Typography>
-      <BookmarkListTable myBookmarkList={bookmarkList} />
+      <Grid container spacing={4} rowSpacing={4}>
+        <BookmarkListTable myBookmarkList={bookmarkList} />
+      </Grid>
     </>
   );
 }

--- a/src/components/buyer/BuyerFavorite.tsx
+++ b/src/components/buyer/BuyerFavorite.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, Typography } from '@mui/material';
+import { Box, Button, Grid, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 import BookmarkListTable from './BookmarkListTable';
 import useGetBookmark from '../../hooks/useGetBookmark';
@@ -12,12 +12,29 @@ export default function BuyerFavorite() {
         <Typography variant="h5" fontWeight={700}>
           찜한 상품 ({bookmarkList.length})
         </Typography>
-        <Typography variant="h6">찜한 상품 목록이 없습니다.</Typography>
-        <Link to={`/`}>
-          <Button type="button" variant="outlined" size="medium">
-            상품 보러 가기
-          </Button>
-        </Link>
+        <Grid item xs={12} style={{ height: '100%' }}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+            style={{ height: '100%' }}
+          >
+            <Typography variant="h6" color="textSecondary">
+              찜한 상품이 없습니다.
+            </Typography>
+            <Link to={`/`}>
+              <Button
+                type="button"
+                variant="outlined"
+                size="medium"
+                sx={{ marginTop: '6px' }}
+              >
+                상품 보러 가기
+              </Button>
+            </Link>
+          </Box>
+        </Grid>
       </>
     );
   }

--- a/src/components/buyer/BuyerHome.tsx
+++ b/src/components/buyer/BuyerHome.tsx
@@ -8,11 +8,12 @@ import {
   styled,
 } from '@mui/material';
 import { Link } from 'react-router-dom';
+import { ChevronRight } from '@mui/icons-material';
 import OrderListTable from './OrderListTable';
 import useGetOrderList from '../../hooks/useGetOrderList';
 import useGetBookmark from '../../hooks/useGetBookmark';
 import BookmarkListTable from './BookmarkListTable';
-import { ChevronRight } from '@mui/icons-material';
+import getState from '../../lib/getState';
 
 export const BuyerHome = () => {
   const id = localStorage.getItem('_id');
@@ -20,6 +21,8 @@ export const BuyerHome = () => {
   const slicedOrderList = orderList.slice(0, 5);
   const bookmarkList = useGetBookmark();
   const sliceBookmarkList = bookmarkList.slice(-5);
+
+  const getStateData = getState(orderList);
 
   let emptyListMessage = '';
 
@@ -87,55 +90,29 @@ export const BuyerHome = () => {
       </Box>
 
       <OrderStateBox>
-        <Grid container height={'90px'} sx={{ flexGrow: 1, width: '100%' }}>
-          <Grid item xs padding={1}>
-            <OrderStateDetail gap={0.5}>
-              <Typography variant="body1" paddingLeft={1}>
-                결제완료
-              </Typography>
+        <>
+          {getStateData.map((state) => (
+            <Grid
+              container
+              height={'90px'}
+              sx={{ flexGrow: 1, width: '100%' }}
+              key={state.id}
+            >
+              <Grid item xs padding={1}>
+                <OrderStateDetail gap={0.5}>
+                  <Typography variant="body1" paddingLeft={1}>
+                    {state.title}
+                  </Typography>
 
-              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
-                0
-              </Avatar>
-            </OrderStateDetail>
-          </Grid>
-          <Divider orientation="vertical"></Divider>
-          <Grid item xs padding={1}>
-            <OrderStateDetail gap={0.5}>
-              <Typography variant="body1" paddingLeft={1}>
-                배송 준비중
-              </Typography>
-
-              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
-                0
-              </Avatar>
-            </OrderStateDetail>
-          </Grid>
-          <Divider orientation="vertical"></Divider>
-          <Grid item xs padding={1}>
-            <OrderStateDetail gap={0.5}>
-              <Typography variant="body1" paddingLeft={1}>
-                배송중
-              </Typography>
-
-              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
-                0
-              </Avatar>
-            </OrderStateDetail>
-          </Grid>
-          <Divider orientation="vertical"></Divider>
-          <Grid item xs padding={1}>
-            <OrderStateDetail gap={0.5}>
-              <Typography variant="body1" paddingLeft={1}>
-                배송 완료
-              </Typography>
-
-              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
-                0
-              </Avatar>
-            </OrderStateDetail>
-          </Grid>
-        </Grid>
+                  <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
+                    {state.count}
+                  </Avatar>
+                </OrderStateDetail>
+              </Grid>
+              <Divider orientation="vertical"></Divider>
+            </Grid>
+          ))}
+        </>
       </OrderStateBox>
 
       {orderList?.length === 0 ? (

--- a/src/components/buyer/BuyerHome.tsx
+++ b/src/components/buyer/BuyerHome.tsx
@@ -1,9 +1,18 @@
-import { Box, Button, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Button,
+  Divider,
+  Grid,
+  Typography,
+  styled,
+} from '@mui/material';
 import { Link } from 'react-router-dom';
 import OrderListTable from './OrderListTable';
 import useGetOrderList from '../../hooks/useGetOrderList';
 import useGetBookmark from '../../hooks/useGetBookmark';
 import BookmarkListTable from './BookmarkListTable';
+import { ChevronRight } from '@mui/icons-material';
 
 export const BuyerHome = () => {
   const id = localStorage.getItem('_id');
@@ -11,6 +20,44 @@ export const BuyerHome = () => {
   const slicedOrderList = orderList.slice(0, 5);
   const bookmarkList = useGetBookmark();
   const sliceBookmarkList = bookmarkList.slice(-5);
+
+  let emptyListMessage = '';
+
+  const emptyList = (listType) => {
+    if (listType === 'order') {
+      emptyListMessage = '주문내역이 없습니다.';
+    } else if (listType === 'favorite') {
+      emptyListMessage = '찜한 상품이 없습니다.';
+    } else {
+      emptyListMessage = '';
+    }
+
+    return (
+      <Grid item xs={12} style={{ height: '30%' }}>
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+          style={{ height: '100%' }}
+        >
+          <Typography variant="body1" color="textSecondary">
+            {emptyListMessage}
+          </Typography>
+          <Link to={`/`}>
+            <Button
+              type="button"
+              variant="outlined"
+              size="medium"
+              sx={{ marginTop: '6px' }}
+            >
+              상품 보러 가기
+            </Button>
+          </Link>
+        </Box>
+      </Grid>
+    );
+  };
 
   return (
     <>
@@ -24,30 +71,122 @@ export const BuyerHome = () => {
           alignItems: 'end',
         }}
       >
-        <Typography variant="h6" fontWeight={600}>
-          내 주문 내역
+        <Typography
+          variant="h6"
+          fontWeight={600}
+          marginTop={2}
+          marginBottom={1}
+        >
+          최근 주문 내역
         </Typography>
         <Link to={`/user/${id}/buyer-orderlist`}>
-          <Button type="button">전체보기</Button>
+          <Button type="button" sx={{ padding: '10px 0' }}>
+            주문내역 더보기 <ChevronRight />
+          </Button>
         </Link>
       </Box>
-      <OrderListTable orderList={slicedOrderList} />
-      <br />
+
+      <OrderStateBox>
+        <Grid container height={'90px'} sx={{ flexGrow: 1, width: '100%' }}>
+          <Grid item xs padding={1}>
+            <OrderStateDetail gap={0.5}>
+              <Typography variant="body1" paddingLeft={1}>
+                결제완료
+              </Typography>
+
+              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
+                0
+              </Avatar>
+            </OrderStateDetail>
+          </Grid>
+          <Divider orientation="vertical"></Divider>
+          <Grid item xs padding={1}>
+            <OrderStateDetail gap={0.5}>
+              <Typography variant="body1" paddingLeft={1}>
+                배송 준비중
+              </Typography>
+
+              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
+                0
+              </Avatar>
+            </OrderStateDetail>
+          </Grid>
+          <Divider orientation="vertical"></Divider>
+          <Grid item xs padding={1}>
+            <OrderStateDetail gap={0.5}>
+              <Typography variant="body1" paddingLeft={1}>
+                배송중
+              </Typography>
+
+              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
+                0
+              </Avatar>
+            </OrderStateDetail>
+          </Grid>
+          <Divider orientation="vertical"></Divider>
+          <Grid item xs padding={1}>
+            <OrderStateDetail gap={0.5}>
+              <Typography variant="body1" paddingLeft={1}>
+                배송 완료
+              </Typography>
+
+              <Avatar sx={{ bgcolor: '#ef5b2a' }} aria-label="recipe">
+                0
+              </Avatar>
+            </OrderStateDetail>
+          </Grid>
+        </Grid>
+      </OrderStateBox>
+
+      {orderList?.length === 0 ? (
+        <>{emptyList('order')}</>
+      ) : (
+        <OrderListTable orderList={slicedOrderList} />
+      )}
+
       <Box
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'end',
+          marginTop: '36px',
         }}
       >
         <Typography variant="h6" fontWeight={600}>
           찜한 상품
         </Typography>
         <Link to={`/user/${id}/buyer-favorite`}>
-          <Button type="button">전체보기</Button>
+          <Button type="button" sx={{ padding: '6px 0' }}>
+            찜한 상품 더보기 <ChevronRight />
+          </Button>
         </Link>
       </Box>
-      <BookmarkListTable myBookmarkList={sliceBookmarkList} />
+      {bookmarkList?.length === 0 ? (
+        <>{emptyList('favorite')}</>
+      ) : (
+        <>
+          <Grid container spacing={4} rowSpacing={4}>
+            <BookmarkListTable myBookmarkList={sliceBookmarkList} />
+          </Grid>
+        </>
+      )}
     </>
   );
 };
+
+const OrderStateBox = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  border: '1px solid rgba(0, 0, 0, 0.12)',
+  marginBottom: '20px',
+  marginTop: '10px',
+});
+
+const OrderStateDetail = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  justifyContent: 'space-between',
+});

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from 'react';
 import {
-  Container,
   Typography,
   TextField,
   FormLabel,
   Button,
   Box,
+  styled,
+  Card,
 } from '@mui/material';
 
 import { api } from '../../api/api';
 import { v4 as uuidv4 } from 'uuid';
 import AddressForm from '../address/AddressForm';
+import { Add } from '@mui/icons-material';
 
 export default function BuyerInfo() {
   const userId = localStorage.getItem('_id');
@@ -213,11 +215,19 @@ export default function BuyerInfo() {
   }
 
   return (
-    <Container>
+    <>
       {userInfo && !isCreateAddress && !isEditAddress && (
         <>
           <Typography variant="h5" fontWeight={700}>
             내 정보 수정
+          </Typography>
+          <Typography
+            variant="h6"
+            fontWeight={600}
+            marginTop={2}
+            marginBottom={1}
+          >
+            개인 정보 수정
           </Typography>
           <form onSubmit={handleUpdateUserInfo}>
             <FormLabel>이메일</FormLabel>
@@ -229,6 +239,7 @@ export default function BuyerInfo() {
               fullWidth
               required
               disabled
+              sx={{ marginBottom: '10px' }}
             />
             <FormLabel>이름</FormLabel>
             <TextField
@@ -240,22 +251,35 @@ export default function BuyerInfo() {
               required
             />
 
-            <Button type="submit" variant="contained" size="large">
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              fullWidth
+              sx={{ marginTop: '12px' }}
+            >
               정보 수정
             </Button>
           </form>
-          <br />
-          <br />
-          {!userInfo.extra.address && <>주소록이 비어있습니다.</>}
+
+          <Typography
+            variant="h6"
+            fontWeight={600}
+            marginTop={5}
+            marginBottom={1}
+          >
+            배송지 관리
+          </Typography>
+          {!userInfo.extra.address && <>등록된 배송지가 없습니다.</>}
           {userInfo?.extra?.address?.length === 0 && (
-            <>주소록이 비어있습니다.</>
+            <>등록된 배송지가 없습니다.</>
           )}
 
           {userInfo.extra.address && (
             <>
               {userInfo.extra.address.map((list) => (
                 // 주소록 목록 테이블 형태로 출력
-                <Box
+                <StyledCard
                   key={list.id}
                   sx={{
                     display: 'flex',
@@ -267,22 +291,19 @@ export default function BuyerInfo() {
                     marginBottom: '0.5rem',
                   }}
                 >
-                  <Box>
-                    <Typography variant="h6" fontWeight={700}>
-                      배송지명: {list.addressName}
+                  <AddrdssDetails padding={1}>
+                    <Typography variant="h6">{list.addressName}</Typography>
+                    <Typography variant="body2" fontWeight={600}>
+                      {list.receiver}
                     </Typography>
-                    <Typography variant="body1">
-                      메인주소: {list.mainAddress}
-                      <br></br>
-                      상세주소: {list.subAddress}
+                    <Typography variant="body2" fontWeight={600}>
+                      {list.tel}
                     </Typography>
-                    <Typography variant="body2">
-                      수령인: {list.receiver}
-                      <br></br>
-                      전화번호: {list.tel}
+                    <Typography variant="body2" fontWeight={600}>
+                      {list.mainAddress} {list.subAddress}
                     </Typography>
-                  </Box>
-                  <Box
+                  </AddrdssDetails>
+                  <AddressActions
                     sx={{
                       display: 'flex',
                       flexDirection: 'column',
@@ -303,8 +324,8 @@ export default function BuyerInfo() {
                     >
                       삭제
                     </Button>
-                  </Box>
-                </Box>
+                  </AddressActions>
+                </StyledCard>
               ))}
             </>
           )}
@@ -312,10 +333,12 @@ export default function BuyerInfo() {
           <Box>
             <Button
               onClick={() => setIsCreateAddress(true)}
-              variant="contained"
+              variant="outlined"
               size="large"
+              fullWidth
+              sx={{ marginTop: '4px' }}
             >
-              주소록 추가하기
+              <Add /> 배송지 신규입력
             </Button>
           </Box>
         </>
@@ -346,6 +369,31 @@ export default function BuyerInfo() {
           />
         </>
       )}
-    </Container>
+    </>
   );
 }
+
+const StyledCard = styled(Card)({
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'relative',
+  boxShadow: 'none',
+  borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+  paddingBottom: '6px',
+});
+
+const AddrdssDetails = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  padding: '2px 4px 6px',
+});
+
+const AddressActions = styled(Box)({
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: '6px',
+  alignItems: 'center',
+  padding: '4px',
+  flexWrap: 'wrap',
+});

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -7,12 +7,14 @@ import {
   Box,
   styled,
   Card,
+  Grid,
 } from '@mui/material';
 
 import { api } from '../../api/api';
 import { v4 as uuidv4 } from 'uuid';
 import AddressForm from '../address/AddressForm';
 import { Add } from '@mui/icons-material';
+import { Link } from 'react-router-dom';
 
 export default function BuyerInfo() {
   const userId = localStorage.getItem('_id');
@@ -214,6 +216,22 @@ export default function BuyerInfo() {
     return <>사용자 정보를 받아오지 못했습니다.</>;
   }
 
+  const emptyAddress = (
+    <Grid item xs={12} style={{ height: '10%' }}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        style={{ height: '100%' }}
+      >
+        <Typography variant="body1" color="textSecondary">
+          등록된 배송지가 없습니다.
+        </Typography>
+      </Box>
+    </Grid>
+  );
+
   return (
     <>
       {userInfo && !isCreateAddress && !isEditAddress && (
@@ -270,10 +288,8 @@ export default function BuyerInfo() {
           >
             배송지 관리
           </Typography>
-          {!userInfo.extra.address && <>등록된 배송지가 없습니다.</>}
-          {userInfo?.extra?.address?.length === 0 && (
-            <>등록된 배송지가 없습니다.</>
-          )}
+          {!userInfo.extra.address && <>{emptyAddress}</>}
+          {userInfo?.extra?.address?.length === 0 && <>{emptyAddress}</>}
 
           {userInfo.extra.address && (
             <>

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -14,7 +14,6 @@ import { api } from '../../api/api';
 import { v4 as uuidv4 } from 'uuid';
 import AddressForm from '../address/AddressForm';
 import { Add } from '@mui/icons-material';
-import { Link } from 'react-router-dom';
 
 export default function BuyerInfo() {
   const userId = localStorage.getItem('_id');

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -120,11 +120,11 @@ export default function BuyerInfo() {
       };
 
       await api.updateUserInfo(userId, updateFormData);
-      alert('주소가 등록되었습니다.');
+      alert('신규 배송지가 등록되었습니다.');
       window.location.reload();
     } catch (error) {
       console.error(error);
-      alert('주소 등록에 실패했습니다.');
+      alert('신규 배송지 등록에 실패했습니다.');
     }
   };
 
@@ -202,11 +202,11 @@ export default function BuyerInfo() {
         },
       };
       await api.updateUserInfo(userId, updateAddressData);
-      alert('주소가 수정되었습니다.');
+      alert('배송지 주소가 수정되었습니다.');
       window.location.reload();
     } catch (error) {
       console.log(error);
-      alert('주소 수정에 실패했습니다.');
+      alert('배송지 주소 수정에 실패했습니다.');
     }
   };
 
@@ -351,7 +351,7 @@ export default function BuyerInfo() {
             func={handleChangeAddress}
             setData={resetData}
             submit={handleSubmitAddress}
-            title={'주소록 추가하기'}
+            title={'배송지 등록'}
             reset={true}
           />
         </>
@@ -364,7 +364,7 @@ export default function BuyerInfo() {
             func={handleChangeEditAddress}
             setData={setIsEditAddress}
             submit={handleSubmitEditAddress}
-            title={'주소록 수정하기'}
+            title={'배송지 수정'}
             reset={false}
           />
         </>

--- a/src/components/buyer/BuyerOrderList.tsx
+++ b/src/components/buyer/BuyerOrderList.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Button, Typography } from '@mui/material';
+import { Box, Button, Grid, Typography } from '@mui/material';
 
 import OrderListTable from './OrderListTable';
 import useGetOrderList from '../../hooks/useGetOrderList';
@@ -7,24 +7,42 @@ import useGetOrderList from '../../hooks/useGetOrderList';
 export default function BuyerOrdeList() {
   const orderList = useGetOrderList();
 
-  if (orderList.length === 0) {
+  if (orderList?.length === 0) {
     return (
       <>
-        <Typography variant="h3" sx={{ marginBottom: '1rem' }}>
-          결제 내역이 없습니다.
+        <Typography variant="h5" fontWeight={700}>
+          내 주문 내역
         </Typography>
-        <Link to={`/`}>
-          <Button type="button" variant="contained" size="large">
-            구매하러 가기
-          </Button>
-        </Link>
+        <Grid item xs={12} style={{ height: '100%' }}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+            style={{ height: '100%' }}
+          >
+            <Typography variant="h6" color="textSecondary">
+              주문 내역이 없습니다.
+            </Typography>
+            <Link to={`/`}>
+              <Button
+                type="button"
+                variant="outlined"
+                size="medium"
+                sx={{ marginTop: '6px' }}
+              >
+                상품 보러 가기
+              </Button>
+            </Link>
+          </Box>
+        </Grid>
       </>
     );
   }
 
   return (
     <>
-      <Typography variant="h5" fontWeight={700}>
+      <Typography variant="h5" fontWeight={700} marginBottom={3}>
         내 주문 내역
       </Typography>
       <OrderListTable orderList={orderList} />

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -4,7 +4,6 @@ import {
   Card,
   CardActionArea,
   CardMedia,
-  Container,
   Grid,
   Typography,
   styled,
@@ -15,7 +14,7 @@ import { Link } from 'react-router-dom';
 export default function BuyerRecentlyView() {
   // 아이템 사이즈를 계산하는 함수
   const getItemSize = () => {
-    return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
+    return { xs: 12, sm: 6, md: 4, lg: 3, xl: 3 };
   };
 
   const recentlyViewedItems = localStorage?.getItem('recentlyViewed');
@@ -24,12 +23,32 @@ export default function BuyerRecentlyView() {
   if (!viewItems || viewItems?.length === 0) {
     return (
       <>
-        <Typography variant="h6">최근 본 상품이 없습니다.</Typography>
-        <Link to={`/`}>
-          <Button type="button" variant="outlined" size="medium">
-            상품 보러 가기
-          </Button>
-        </Link>
+        <Typography variant="h5" fontWeight={700}>
+          최근 본 상품
+        </Typography>
+        <Grid item xs={12} style={{ height: '100%' }}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+            style={{ height: '100%' }}
+          >
+            <Typography variant="h6" color="textSecondary">
+              최근 본 상품이 없습니다.
+            </Typography>
+            <Link to={`/`}>
+              <Button
+                type="button"
+                variant="outlined"
+                size="medium"
+                sx={{ marginTop: '6px' }}
+              >
+                상품 보러 가기
+              </Button>
+            </Link>
+          </Box>
+        </Grid>
       </>
     );
   }

--- a/src/components/buyer/BuyerRecentlyView.tsx
+++ b/src/components/buyer/BuyerRecentlyView.tsx
@@ -5,6 +5,7 @@ import {
   CardActionArea,
   CardMedia,
   Container,
+  Grid,
   Typography,
   styled,
 } from '@mui/material';
@@ -12,6 +13,11 @@ import {
 import { Link } from 'react-router-dom';
 
 export default function BuyerRecentlyView() {
+  // 아이템 사이즈를 계산하는 함수
+  const getItemSize = () => {
+    return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
+  };
+
   const recentlyViewedItems = localStorage?.getItem('recentlyViewed');
   const viewItems = JSON.parse(recentlyViewedItems)?.state?.viewItems;
 
@@ -30,36 +36,29 @@ export default function BuyerRecentlyView() {
 
   return (
     <>
-      <Container>
-        <Typography variant="h5" fontWeight={700}>
-          최근 본 상품
-        </Typography>
+      <Typography variant="h5" fontWeight={700}>
+        최근 본 상품
+      </Typography>
+      <Grid container spacing={4} rowSpacing={4}>
         {viewItems.map((product) => (
-          <StyledCard key={product._id}>
-            <CardActionArea component={Link} to={`/product/${product._id}`}>
-              <ProductImage
-                image={product.mainImages[0].path}
-                title={product.name}
-              />
-              <ProductDetails>
-                <Typography variant="h6">{product.name}</Typography>
-                <Typography variant="h6" color="inherit" fontWeight={700}>
-                  {product.price.toLocaleString()} 원
-                </Typography>
-              </ProductDetails>
-            </CardActionArea>
-            <ProductActions>
-              <ShippingFee>
-                <Typography variant="body2">
-                  {product.shippingFees === 0
-                    ? '무료배송'
-                    : '배송료: ' + product.shippingFees.toLocaleString() + '원'}
-                </Typography>
-              </ShippingFee>
-            </ProductActions>
-          </StyledCard>
+          <Grid item {...getItemSize()} key={product._id} marginTop={3}>
+            <StyledCard>
+              <CardActionArea component={Link} to={`/product/${product._id}`}>
+                <ProductImage
+                  image={product.mainImages[0].path}
+                  title={product.name}
+                />
+                <ProductDetails>
+                  <Typography variant="h6">{product.name}</Typography>
+                  <Typography variant="h6" color="inherit" fontWeight={700}>
+                    {product.price.toLocaleString()} 원
+                  </Typography>
+                </ProductDetails>
+              </CardActionArea>
+            </StyledCard>
+          </Grid>
         ))}
-      </Container>
+      </Grid>
     </>
   );
 }
@@ -82,17 +81,5 @@ const ProductDetails = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'start',
-  padding: '16px',
-});
-
-const ProductActions = styled(Box)({
-  display: 'flex',
-  justifyContent: 'flex-end',
-  alignItems: 'center',
-  padding: '8px',
-});
-
-const ShippingFee = styled(Box)({
-  flexGrow: 1,
-  padding: '0 8px',
+  padding: '12px 4px 6px',
 });

--- a/src/lib/deleteBookmark.ts
+++ b/src/lib/deleteBookmark.ts
@@ -1,15 +1,16 @@
 import { api } from '../api/api';
 
 export default async function deleteBookmark(bookmarkId: number) {
-  const confirmRemoveBookmark = window.confirm('북마크를 삭제하시겠습니까?');
+  const confirmRemoveBookmark =
+    window.confirm('찜한 상품에서 삭제하시겠습니까?');
 
   if (confirmRemoveBookmark) {
     try {
       await api.removeBookmark(Number(bookmarkId));
-      alert('bookmark 삭제 성공');
+      alert('찜한 상품에서 삭제되었습니다.');
       window.location.reload();
     } catch (error) {
-      console.log('북마크 삭제에 실패했습니다.');
+      console.log('찜한 상품 삭제에 실패했습니다.');
     }
   }
 }

--- a/src/lib/getState.ts
+++ b/src/lib/getState.ts
@@ -10,7 +10,6 @@ export default function getState(orderList) {
 
   let result = _.countBy(orderList, 'state');
   result = _.merge({}, state, result);
-  console.log(result);
 
   const stateTitle = [
     {

--- a/src/lib/getState.ts
+++ b/src/lib/getState.ts
@@ -1,0 +1,39 @@
+import _ from 'lodash';
+
+export default function getState(orderList) {
+  const state = {
+    OS020: 0,
+    OS030: 0,
+    OS035: 0,
+    OS040: 0,
+  };
+
+  let result = _.countBy(orderList, 'state');
+  result = _.merge({}, state, result);
+  console.log(result);
+
+  const stateTitle = [
+    {
+      id: 1,
+      title: '결제완료',
+      count: result.OS020,
+    },
+    {
+      id: 2,
+      title: '배송준비중',
+      count: result.OS030,
+    },
+    {
+      id: 3,
+      title: '배송중',
+      count: result.OS035,
+    },
+    {
+      id: 4,
+      title: '배송완료',
+      count: result.OS040,
+    },
+  ];
+
+  return stateTitle;
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #87 


## 🔎 구현한 내용
- 북마크 페이지 화면 작업
- 대시보드 페이지 마진, 패딩 구조 통일(구매자 대시보드 쪽만)
- (기능) 북마크 페이지에서 장바구니 기능 연결
- (기능) 대시보드 메인 페이지에서 각 주문 상태별 건수 표시


## 📸 스크린샷(선택사항)

<img width="1306" alt="스크린샷 2023-12-18 오후 7 13 19" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/74ebce2c-b8c5-4af6-861c-ff13f4f7366b">


## 🙌 리뷰어에게
- 디자인 작업 진행하면서 이슈로 따로 빼기 애매한 기능들을 같이 작업했습니다.
   - 코드 리뷰  076a90f ,  e52c106 기능 구현 부분 부탁드립니다!
- 주문 상태별 건수 표시를 위해 객체, 배열 변환에 유용한 유틸 라이브러리인 [lodash](https://lodash.com/)를 사용했습니다. npm i 꼭 해주세요!
- 주문내역의 별점 평가는 내 주문 내역 추가 작업에서 진행하겠습니다.