### PR TITLE
Fix: 대시보드 사이드바-새로고침시 active 상태가 기본값으로 변경되는 이슈

### DIFF
--- a/src/components/DashboardNavBar.tsx
+++ b/src/components/DashboardNavBar.tsx
@@ -1,0 +1,94 @@
+import Divider from '@mui/material/Divider';
+import InboxIcon from '@mui/icons-material/MoveToInbox';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MailIcon from '@mui/icons-material/Mail';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import { Link, useLocation } from 'react-router-dom';
+import { Box, Grid } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+export default function DashboardNavBar({ dashboardMenu }) {
+  const location = useLocation();
+  const [selectedMenu, setSelectedMenu] = useState('');
+
+  useEffect(() => {
+    setSelectedMenu(location.pathname);
+  }, [location.pathname]);
+
+  return (
+    <>
+      <Grid item xs={3}>
+        <Toolbar />
+        <Divider />
+        <List>
+          <Box sx={{ padding: '20px 16px 8px' }}>
+            <Typography variant="h6" fontWeight={700}>
+              구매자
+            </Typography>
+          </Box>
+          {dashboardMenu.buyer.map((items) => (
+            <ListItem key={items.id} disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                </ListItemIcon>
+                <Link
+                  to={items.url}
+                  style={{ textDecoration: 'none', color: 'inherit' }}
+                >
+                  <ListItemText
+                    primary={items.title}
+                    primaryTypographyProps={{
+                      fontSize: '16',
+                      letterSpacing: 0,
+                      fontWeight:
+                        selectedMenu === items.url ? 'bold' : 'medium',
+                    }}
+                    onClick={() => setSelectedMenu(items.url)}
+                  />
+                </Link>
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+        <Divider />
+        <List>
+          <Box sx={{ padding: '20px 16px 8px' }}>
+            <Typography variant="h6" fontWeight={700}>
+              판매자
+            </Typography>
+          </Box>
+          {dashboardMenu.seller.map((items) => (
+            <ListItem key={items.id} disablePadding>
+              <ListItemButton>
+                <ListItemIcon>
+                  {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                </ListItemIcon>
+                <Link
+                  to={items.url}
+                  style={{ textDecoration: 'none', color: 'inherit' }}
+                >
+                  <ListItemText
+                    primary={items.title}
+                    primaryTypographyProps={{
+                      fontSize: '16',
+                      letterSpacing: 0,
+                      fontWeight:
+                        selectedMenu === items.url ? 'bold' : 'medium',
+                    }}
+                    onClick={() => setSelectedMenu(items.url)}
+                  />
+                </Link>
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Grid>
+    </>
+  );
+}

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -211,9 +211,21 @@ export default function BuyerInfo() {
     }
   };
 
-  if (!userInfo) {
-    return <>사용자 정보를 받아오지 못했습니다.</>;
-  }
+  const emptyUser = (
+    <Grid item xs={12} style={{ height: '100%' }}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        style={{ height: '100%' }}
+      >
+        <Typography variant="h6" color="textSecondary">
+          사용자 정보를 받아오지 못했습니다.
+        </Typography>
+      </Box>
+    </Grid>
+  );
 
   const emptyAddress = (
     <Grid item xs={12} style={{ height: '10%' }}>
@@ -233,11 +245,12 @@ export default function BuyerInfo() {
 
   return (
     <>
+      <Typography variant="h5" fontWeight={700}>
+        내 정보 수정
+      </Typography>
+      {!userInfo && <>{emptyUser}</>}
       {userInfo && !isCreateAddress && !isEditAddress && (
         <>
-          <Typography variant="h5" fontWeight={700}>
-            내 정보 수정
-          </Typography>
           <Typography
             variant="h6"
             fontWeight={600}

--- a/src/components/buyer/BuyerInfo.tsx
+++ b/src/components/buyer/BuyerInfo.tsx
@@ -245,12 +245,19 @@ export default function BuyerInfo() {
 
   return (
     <>
-      <Typography variant="h5" fontWeight={700}>
-        내 정보 수정
-      </Typography>
-      {!userInfo && <>{emptyUser}</>}
+      {!userInfo && (
+        <>
+          <Typography variant="h5" fontWeight={700}>
+            내 정보 수정
+          </Typography>
+          {emptyUser}
+        </>
+      )}
       {userInfo && !isCreateAddress && !isEditAddress && (
         <>
+          <Typography variant="h5" fontWeight={700}>
+            내 정보 수정
+          </Typography>
           <Typography
             variant="h6"
             fontWeight={600}

--- a/src/pages/user/Dashboard.tsx
+++ b/src/pages/user/Dashboard.tsx
@@ -2,22 +2,14 @@ import * as React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
-import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
-import InboxIcon from '@mui/icons-material/MoveToInbox';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import MailIcon from '@mui/icons-material/Mail';
 import MenuIcon from '@mui/icons-material/Menu';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { Link, Outlet } from 'react-router-dom';
 import { DASHBOARD_MENU } from '../../constants';
-import { Grid } from '@mui/material';
+import DashboardNavBar from '../../components/DashboardNavBar';
 
 const drawerWidth = 240;
 
@@ -28,94 +20,12 @@ interface Props {
 export default function Dashboard(props: Props) {
   const { window } = props;
   const [mobileOpen, setMobileOpen] = React.useState(false);
-  const [selectedBuyerMenu, setSelectedBuyerMenu] = React.useState(
-    DASHBOARD_MENU.buyer[0].title,
-  );
-  const [selectSellerMenu, setSelectSellerMenu] = React.useState('');
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
   };
 
-  const handleSelectBuyerMenu = (itemBuyerTitle: string) => {
-    setSelectedBuyerMenu(itemBuyerTitle);
-    setSelectSellerMenu('');
-  };
-
-  const handleSelectSellerMenu = (itemSellerTitle: string) => {
-    setSelectSellerMenu(itemSellerTitle);
-    setSelectedBuyerMenu('');
-  };
-
-  const drawer = (
-    <Grid item xs={3}>
-      <Toolbar />
-      <Divider />
-      <List>
-        <Box sx={{ padding: '20px 16px 8px' }}>
-          <Typography variant="h6" fontWeight={700}>
-            구매자
-          </Typography>
-        </Box>
-        {DASHBOARD_MENU.buyer.map((items) => (
-          <ListItem key={items.id} disablePadding>
-            <ListItemButton>
-              <ListItemIcon>
-                {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-              </ListItemIcon>
-              <Link
-                to={items.url}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                <ListItemText
-                  primary={items.title}
-                  primaryTypographyProps={{
-                    fontSize: '16',
-                    fontWeight:
-                      selectedBuyerMenu === items.title ? 'bold' : 'medium',
-                    letterSpacing: 0,
-                  }}
-                  onClick={() => handleSelectBuyerMenu(items.title)}
-                />
-              </Link>
-            </ListItemButton>
-          </ListItem>
-        ))}
-      </List>
-      <Divider />
-      <List>
-        <Box sx={{ padding: '20px 16px 8px' }}>
-          <Typography variant="h6" fontWeight={700}>
-            판매자
-          </Typography>
-        </Box>
-        {DASHBOARD_MENU.seller.map((items) => (
-          <ListItem key={items.id} disablePadding>
-            <ListItemButton>
-              <ListItemIcon>
-                {items.id % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-              </ListItemIcon>
-              <Link
-                to={items.url}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                <ListItemText
-                  primary={items.title}
-                  primaryTypographyProps={{
-                    fontSize: '16',
-                    fontWeight:
-                      selectSellerMenu === items.title ? 'bold' : 'medium',
-                    letterSpacing: 0,
-                  }}
-                  onClick={() => handleSelectSellerMenu(items.title)}
-                />
-              </Link>
-            </ListItemButton>
-          </ListItem>
-        ))}
-      </List>
-    </Grid>
-  );
+  const drawer = <DashboardNavBar dashboardMenu={DASHBOARD_MENU} />;
 
   // Remove this const when copying and pasting into your project.
   const container =


### PR DESCRIPTION
## 🧾 관련 이슈
close : #93 


## 🔎 구현한 내용
- 내 정보 수정하기 페이지 : 사용자 정보 없을 때 보여지는 에러 페이지 수정
- 대시보드 사이드바 active 이슈 해결


## 📸 스크린샷(선택사항)
<img width="700" alt="image" src="https://github.com/PhoenixFE/orum-market-front/assets/104605709/9cb4b2cd-b89e-4e08-a875-b685ece3a9c2">


## 🙌 리뷰어에게
- React Router Dom의 [useLocation](https://reactrouter.com/en/main/hooks/use-location)으로 현재 페이지의 url 경로와 선택된 주소 url이 같은 경우 active 상태가 유지되도록 처리해주었습니다.

