### PR TITLE
Refactor: 정렬 API 적용

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-VITE_API_BASE_URL=https://orum-jingoworld.koyeb.app/api/
+VITE_API_BASE_URL=https://localhost/api
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -182,7 +182,11 @@ export const api = {
   getOrderProductInfo: () => axiosInstance.get<IOrderRes>('/orders/'),
 
   //판매자 주문 목록 조회
-  getOrderState: () => axiosInstance.get('seller/orders/'),
+  getOrderState: (query: IProductListQuery = {}) => {
+    const queryString = new URLSearchParams(query as any).toString();
+    const response = axiosInstance.get(`seller/orders?${queryString}`);
+    return response;
+  },
 
   //판매자 주문상태 수정
   updateOrderState: (_id: number, product_id: number, state: any) =>

--- a/src/components/navbar/NavigationBar.tsx
+++ b/src/components/navbar/NavigationBar.tsx
@@ -33,7 +33,7 @@ export default function NavigationBar({
   handleSort,
   handleDisplayChange,
 }: INavigationBar) {
-  const [selectedSortOrder, setSelectedSortOrder] = useState<string>('최신순');
+  const [selectedSortOrder, setSelectedSortOrder] = useState<string>('latest');
   const [itemsPerPage, setItemsPerPage] = useState<number>(4);
   const theme = useTheme();
   const isMdDown = useMediaQuery(theme.breakpoints.down('md'));

--- a/src/components/search/ProductGrid.tsx
+++ b/src/components/search/ProductGrid.tsx
@@ -1,5 +1,5 @@
 import { Grid, Typography, Box, Grow } from '@mui/material';
-import { Skeleton } from '@mui/material';
+// import { Skeleton } from '@mui/material';
 import { IProduct } from '../../type';
 import { ProductCard } from '../../pages/product/ProductCard';
 
@@ -24,19 +24,19 @@ export const ProductGrid = ({
     return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
   };
 
-  const ProductSkeleton = () => {
-    return (
-      <Grid container spacing={4} m={4}>
-        {Array.from(new Array(itemsPerPage)).map((_, index) => (
-          <Grid item key={index} {...getItemSize()}>
-            <Skeleton variant="rectangular" height={200} />
-            <Skeleton variant="text" />
-            <Skeleton variant="text" />
-          </Grid>
-        ))}
-      </Grid>
-    );
-  };
+  // const ProductSkeleton = () => {
+  //   return (
+  //     <Grid container spacing={4} m={4}>
+  //       {Array.from(new Array(itemsPerPage)).map((_, index) => (
+  //         <Grid item key={index} {...getItemSize()}>
+  //           <Skeleton variant="rectangular" height={200} />
+  //           <Skeleton variant="text" />
+  //           <Skeleton variant="text" />
+  //         </Grid>
+  //       ))}
+  //     </Grid>
+  //   );
+  // };
 
   const renderNoProductsMessage = () => {
     if (isDataFetched && filteredProducts.length === 0) {

--- a/src/components/search/ProductGrid.tsx
+++ b/src/components/search/ProductGrid.tsx
@@ -4,7 +4,7 @@ import { IProduct } from '../../type';
 import { ProductCard } from '../../pages/product/ProductCard';
 
 interface ProductGridProps {
-  isLoading: boolean;
+  // isLoading: boolean;
   isDataFetched: boolean;
   filteredProducts: IProduct[];
   itemsPerPage: number;
@@ -12,7 +12,7 @@ interface ProductGridProps {
 }
 
 export const ProductGrid = ({
-  isLoading,
+  // isLoading,
   isDataFetched,
   filteredProducts,
   itemsPerPage,
@@ -39,7 +39,7 @@ export const ProductGrid = ({
   };
 
   const renderNoProductsMessage = () => {
-    if (!isLoading && isDataFetched && filteredProducts.length === 0) {
+    if (isDataFetched && filteredProducts.length === 0) {
       return (
         <Grid item xs={12} style={{ height: '100%' }}>
           <Box
@@ -59,9 +59,9 @@ export const ProductGrid = ({
   };
 
   const renderProductsOrSkeletons = () => {
-    if (isLoading) {
-      return <ProductSkeleton />;
-    }
+    // if (isLoading) {
+    //   return <ProductSkeleton />;
+    // }
 
     return (
       <>

--- a/src/components/search/ProductGrid.tsx
+++ b/src/components/search/ProductGrid.tsx
@@ -24,6 +24,7 @@ export const ProductGrid = ({
     return { xs: 12, sm: 6, md: 4, lg: 4, xl: 4 };
   };
 
+  // TODO : reactQuery 작업할 때 사용 예정
   // const ProductSkeleton = () => {
   //   return (
   //     <Grid container spacing={4} m={4}>
@@ -59,6 +60,7 @@ export const ProductGrid = ({
   };
 
   const renderProductsOrSkeletons = () => {
+    // TODO : reactQuery
     // if (isLoading) {
     //   return <ProductSkeleton />;
     // }

--- a/src/components/seller/SellerOrderManager.tsx
+++ b/src/components/seller/SellerOrderManager.tsx
@@ -146,7 +146,7 @@ export default function SellerOrderManager() {
               </TableBody>
             )}
             {isLoading && <SkeletonTable rows={5} columns={9} />}
-            {sortedProducts.map((orderItem) => (
+            {sortedProducts.map((orderItem: IOrderItem) => (
               <TableBody key={orderItem._id}>
                 {orderItem.products.map((productItem) => (
                   <TableRow key={productItem._id}>

--- a/src/components/seller/SellerOrderManager.tsx
+++ b/src/components/seller/SellerOrderManager.tsx
@@ -18,15 +18,30 @@ import { useEffect, useState } from 'react';
 
 import { api } from '../../api/api';
 import { IOrderItem } from '../../type';
-import { QUALITY, ORDER_STATE } from '../../constants/index';
+import {
+  QUALITY,
+  ORDER_STATE,
+  SORT_OPTIONS_DASHBOARD,
+} from '../../constants/index';
 import formatDate from '../../lib/formatDate';
 import SkeletonTable from './SkeletonTable';
+import { useSort } from '../../hooks/useSort';
 
 export default function SellerOrderManager() {
   const [sortedOrderList, setSortedOrderList] = useState<IOrderItem[]>([]);
-  const [sortOrder, setSortOrder] = useState('최신순');
+  const [sortOrder, setSortOrder] = useState<string>('latest');
   const [orderList, setOrderList] = useState<IOrderItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  const [sortedProducts, setCurrentSortOrder] = useSort(
+    sortedOrderList,
+    'latest',
+  ) as any;
+
+  const onSortChange = (sortValue: string) => {
+    setSortOrder(sortValue);
+    setCurrentSortOrder(sortValue);
+  };
 
   useEffect(() => {
     const getOrderState = async () => {
@@ -44,33 +59,6 @@ export default function SellerOrderManager() {
     };
     getOrderState();
   }, []);
-
-  useEffect(() => {
-    let sorted = [...orderList];
-    switch (sortOrder) {
-      case '최신순':
-        sorted.sort(
-          (a, b) =>
-            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-        );
-        break;
-      case '오래된순':
-        sorted.sort(
-          (a, b) =>
-            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-        );
-        break;
-      case '가-하':
-        sorted.sort((a, b) => a.cost.total - b.cost.total);
-        break;
-      case '하-가':
-        sorted.sort((a, b) => b.cost.total - a.cost.total);
-        break;
-      default:
-        break;
-    }
-    setSortedOrderList(sorted);
-  }, [orderList, sortOrder]);
 
   const getQualityName = (quantity: number) => {
     const qualityItem = QUALITY.find((q) => q.value === quantity);
@@ -130,16 +118,18 @@ export default function SellerOrderManager() {
         <FormControl>
           <InputLabel id="sort-label">정렬</InputLabel>
           <Select
-            labelId="sort-label"
+            labelId="sort-select-label"
             id="sort-select"
             value={sortOrder}
             size="small"
-            onChange={(e) => setSortOrder(e.target.value)}
+            sx={{ fontSize: '0.9rem', borderRadius: 0 }}
+            onChange={(event) => onSortChange(event.target.value as string)}
           >
-            <MenuItem value="최신순">최신순</MenuItem>
-            <MenuItem value="오래된순">오래된순</MenuItem>
-            <MenuItem value="가-하">가격: 낮은 순</MenuItem>
-            <MenuItem value="하-가">가격: 높은 순</MenuItem>
+            {SORT_OPTIONS_DASHBOARD.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
           </Select>
         </FormControl>
         <TableContainer component={Paper}>

--- a/src/components/seller/SellerOrderManager.tsx
+++ b/src/components/seller/SellerOrderManager.tsx
@@ -18,11 +18,7 @@ import { useState } from 'react';
 
 import { api } from '../../api/api';
 import { IOrderItem } from '../../type';
-import {
-  QUALITY,
-  ORDER_STATE,
-  SORT_OPTIONS_DASHBOARD,
-} from '../../constants/index';
+import { QUALITY, ORDER_STATE, SORT_OPTIONS } from '../../constants/index';
 import formatDate from '../../lib/formatDate';
 import SkeletonTable from './SkeletonTable';
 import { useSort } from '../../hooks/useSort';
@@ -109,7 +105,7 @@ export default function SellerOrderManager() {
             sx={{ fontSize: '0.9rem', borderRadius: 0 }}
             onChange={(event) => onSortChange(event.target.value as string)}
           >
-            {SORT_OPTIONS_DASHBOARD.map((option) => (
+            {SORT_OPTIONS.map((option) => (
               <MenuItem key={option.value} value={option.value}>
                 {option.label}
               </MenuItem>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -256,10 +256,10 @@ export const ORDER_STATE = {
 };
 
 export const SORT_OPTIONS = [
-  { label: '최신순', value: '최신순' },
-  { label: '오래된순', value: '오래된순' },
-  { label: '높은가격순', value: '높은가격순' },
-  { label: '낮은가격순', value: '낮은가격순' },
+  { label: '최신순', value: '최신순', sortQuery: 'latest' },
+  { label: '오래된순', value: '오래된순', sortQuery: 'oldest' },
+  { label: '높은가격순', value: '높은가격순', sortQuery: 'maxPrice' },
+  { label: '낮은가격순', value: '낮은가격순', sortQuery: 'minPrice' },
 ];
 
 export const PRICE_BOUNDARIES: { [key: string]: { min: number; max: number } } =

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -262,13 +262,6 @@ export const SORT_OPTIONS = [
   { label: '낮은가격순', value: 'minPrice' },
 ];
 
-export const SORT_OPTIONS_DASHBOARD = [
-  { label: '최근주문순', value: 'latest' },
-  { label: '오래된주문순', value: 'oldest' },
-  { label: '최고결제금액순', value: 'maxPrice' },
-  { label: '최저결제금액순', value: 'minPrice' },
-];
-
 export const PRICE_BOUNDARIES: { [key: string]: { min: number; max: number } } =
   {
     전체: { min: 0, max: Infinity },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -256,10 +256,10 @@ export const ORDER_STATE = {
 };
 
 export const SORT_OPTIONS = [
-  { label: '최신순', value: '최신순', sortQuery: 'latest' },
-  { label: '오래된순', value: '오래된순', sortQuery: 'oldest' },
-  { label: '높은가격순', value: '높은가격순', sortQuery: 'maxPrice' },
-  { label: '낮은가격순', value: '낮은가격순', sortQuery: 'minPrice' },
+  { label: '최신순', value: 'latest' },
+  { label: '오래된순', value: 'oldest' },
+  { label: '높은가격순', value: 'maxPrice' },
+  { label: '낮은가격순', value: 'minPrice' },
 ];
 
 export const PRICE_BOUNDARIES: { [key: string]: { min: number; max: number } } =

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -262,6 +262,13 @@ export const SORT_OPTIONS = [
   { label: '낮은가격순', value: 'minPrice' },
 ];
 
+export const SORT_OPTIONS_DASHBOARD = [
+  { label: '최근주문순', value: 'latest' },
+  { label: '오래된주문순', value: 'oldest' },
+  { label: '최고결제금액순', value: 'maxPrice' },
+  { label: '최저결제금액순', value: 'minPrice' },
+];
+
 export const PRICE_BOUNDARIES: { [key: string]: { min: number; max: number } } =
   {
     전체: { min: 0, max: Infinity },

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { IProduct } from '../type';
 import { api } from '../api/api';
 
 export const useSort = (products: IProduct[], initialSortOrder: string) => {
   const [sortedProducts, setSortedProducts] = useState(products);
   const [currentSortOrder, setCurrentSortOrder] = useState(initialSortOrder);
+  const location = useLocation();
+  const path = location.pathname;
 
   useEffect(() => {
     if (!Array.isArray(products)) {
@@ -28,15 +31,19 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
         break;
     }
 
-    const sortFetchProducts = async () => {
+    // path === '/'면 getProductList, 'order'이면 getOrderState
+    const sortFetchProducts = async (path: string) => {
       try {
-        const response = await api.getProductList(sortQuery);
+        const response =
+          path === '/'
+            ? await api.getProductList(sortQuery)
+            : await api.getOrderState(sortQuery);
         setSortedProducts(response.data.item);
       } catch (error) {
         console.log('데이터를 받아오지 못했습니다.', error);
       }
     };
-    sortFetchProducts();
+    sortFetchProducts(path);
   }, [products, currentSortOrder]);
 
   return [sortedProducts, setCurrentSortOrder];

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -53,11 +53,18 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
     const sortFetchProducts = async (path: string) => {
       try {
         setIsLoading(true);
-        const response =
-          path === '/'
-            ? await api.getProductList(sortQuery)
-            : await api.getOrderState(sortQuery);
-        setSortedProducts(response.data.item);
+        let response;
+
+        switch (path) {
+          case '/':
+            response = await api.getProductList(sortQuery);
+            break;
+          case 'orders':
+            response = await api.getOrderState(sortQuery);
+            break;
+        }
+
+        setSortedProducts(response?.data.item);
         setIsLoading(false);
       } catch (error) {
         console.log('데이터를 받아오지 못했습니다.', error);

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { IProduct, IOrderItem } from '../type';
+import { IProduct } from '../type';
 import { api } from '../api/api';
 
 export const useSort = (products: IProduct[], initialSortOrder: string) => {
@@ -64,6 +64,7 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
         setIsLoading(false);
       }
     };
+
     sortFetchProducts(currnetQuery);
   }, [products, currentSortOrder]);
 

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -9,17 +9,17 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
   const location = useLocation();
   const [isLoading, setIsLoading] = useState(true);
 
-  let currnetQuery = '';
+  let productsSort = '';
   const getCurrentPath = () => {
     const path = location.pathname;
 
     if (path === '/') {
-      currnetQuery = path;
-      return currnetQuery;
+      productsSort = path;
+      return productsSort;
     } else {
-      const pathSplit = path.split('/');
-      currnetQuery = pathSplit[pathSplit.length - 1];
-      return currnetQuery;
+      const pathnames = path.split('/');
+      productsSort = pathnames[pathnames.length - 1];
+      return productsSort;
     }
   };
 
@@ -41,19 +41,19 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
         break;
       case 'maxPrice':
         sortQuery =
-          currnetQuery === '/' ? `sort={"price": -1}` : `sort={"cost": -1}`;
+          productsSort === '/' ? `sort={"price": -1}` : `sort={"cost": -1}`;
         break;
       case 'minPrice':
         sortQuery =
-          currnetQuery === '/' ? `sort={"price": 1}` : `sort={"cost": 1}`;
+          productsSort === '/' ? `sort={"price": 1}` : `sort={"cost": 1}`;
         break;
     }
 
     // path === '/'면 getProductList, 'order'이면 getOrderState
-    const sortFetchProducts = async (path: string) => {
+    const fetchSortedProducts = async (path: string) => {
       try {
         setIsLoading(true);
-        let response;
+        let response = null;
 
         switch (path) {
           case '/':
@@ -72,7 +72,7 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
       }
     };
 
-    sortFetchProducts(currnetQuery);
+    fetchSortedProducts(productsSort);
   }, [products, currentSortOrder]);
 
   return [sortedProducts, setCurrentSortOrder, isLoading];

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -24,10 +24,10 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
         sortQuery = `sort={"createdAt": 1}`;
         break;
       case 'maxPrice':
-        sortQuery = `sort={"price": -1}`;
+        sortQuery = path === '/' ? `sort={"price": -1}` : `sort={"cost": -1}`;
         break;
       case 'minPrice':
-        sortQuery = `sort={"price": 1}`;
+        sortQuery = path === '/' ? `sort={"price": 1}` : `sort={"cost": 1}`;
         break;
     }
 
@@ -36,8 +36,8 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
       try {
         const response =
           path === '/'
-            ? await api.getProductList(sortQuery)
-            : await api.getOrderState(sortQuery);
+            ? await api.getOrderState(sortQuery)
+            : await api.getProductList(sortQuery);
         setSortedProducts(response.data.item);
       } catch (error) {
         console.log('데이터를 받아오지 못했습니다.', error);

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -7,7 +7,25 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
   const [sortedProducts, setSortedProducts] = useState(products);
   const [currentSortOrder, setCurrentSortOrder] = useState(initialSortOrder);
   const location = useLocation();
-  const path = location.pathname;
+
+  let currnetQuery = '';
+  const getCurrentPath = () => {
+    const path = location.pathname;
+
+    if (path === '/') {
+      currnetQuery = path;
+      return currnetQuery;
+    } else {
+      const pathSplit = path.split('/');
+      currnetQuery = pathSplit[pathSplit.length - 1];
+      return currnetQuery;
+    }
+  };
+
+  getCurrentPath();
+
+  // console.log('currnetQuery:', currnetQuery);
+  // console.log('sortedProducts: ', sortedProducts);
 
   useEffect(() => {
     if (!Array.isArray(products)) {
@@ -24,10 +42,12 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
         sortQuery = `sort={"createdAt": 1}`;
         break;
       case 'maxPrice':
-        sortQuery = path === '/' ? `sort={"price": -1}` : `sort={"cost": -1}`;
+        sortQuery =
+          currnetQuery === '/' ? `sort={"price": -1}` : `sort={"cost": -1}`;
         break;
       case 'minPrice':
-        sortQuery = path === '/' ? `sort={"price": 1}` : `sort={"cost": 1}`;
+        sortQuery =
+          currnetQuery === '/' ? `sort={"price": 1}` : `sort={"cost": 1}`;
         break;
     }
 
@@ -36,14 +56,14 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
       try {
         const response =
           path === '/'
-            ? await api.getOrderState(sortQuery)
-            : await api.getProductList(sortQuery);
+            ? await api.getProductList(sortQuery)
+            : await api.getOrderState(sortQuery);
         setSortedProducts(response.data.item);
       } catch (error) {
         console.log('데이터를 받아오지 못했습니다.', error);
       }
     };
-    sortFetchProducts(path);
+    sortFetchProducts(currnetQuery);
   }, [products, currentSortOrder]);
 
   return [sortedProducts, setCurrentSortOrder];

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { IProduct } from '../type';
+import { IProduct, IOrderItem } from '../type';
 import { api } from '../api/api';
 
 export const useSort = (products: IProduct[], initialSortOrder: string) => {
   const [sortedProducts, setSortedProducts] = useState(products);
   const [currentSortOrder, setCurrentSortOrder] = useState(initialSortOrder);
   const location = useLocation();
+  const [isLoading, setIsLoading] = useState(true);
 
   let currnetQuery = '';
   const getCurrentPath = () => {
@@ -23,9 +24,6 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
   };
 
   getCurrentPath();
-
-  // console.log('currnetQuery:', currnetQuery);
-  // console.log('sortedProducts: ', sortedProducts);
 
   useEffect(() => {
     if (!Array.isArray(products)) {
@@ -54,17 +52,20 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
     // path === '/'면 getProductList, 'order'이면 getOrderState
     const sortFetchProducts = async (path: string) => {
       try {
+        setIsLoading(true);
         const response =
           path === '/'
             ? await api.getProductList(sortQuery)
             : await api.getOrderState(sortQuery);
         setSortedProducts(response.data.item);
+        setIsLoading(false);
       } catch (error) {
         console.log('데이터를 받아오지 못했습니다.', error);
+        setIsLoading(false);
       }
     };
     sortFetchProducts(currnetQuery);
   }, [products, currentSortOrder]);
 
-  return [sortedProducts, setCurrentSortOrder];
+  return [sortedProducts, setCurrentSortOrder, isLoading];
 };

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IProduct } from '../type';
+import { api } from '../api/api';
 
 export const useSort = (products: IProduct[], initialSortOrder: string) => {
   const [sortedProducts, setSortedProducts] = useState(products);
@@ -11,29 +12,31 @@ export const useSort = (products: IProduct[], initialSortOrder: string) => {
       return;
     }
 
-    let sorted = [...products];
+    let sortQuery = {};
     switch (currentSortOrder) {
-      case '최신순':
-        sorted.sort(
-          (a, b) =>
-            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-        );
+      case 'latest':
+        sortQuery = `sort={"createdAt": -1}`;
         break;
-      case '오래된순':
-        sorted.sort(
-          (a, b) =>
-            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-        );
+      case 'oldest':
+        sortQuery = `sort={"createdAt": 1}`;
         break;
-      case '높은가격순':
-        sorted.sort((a, b) => b.price - a.price);
+      case 'maxPrice':
+        sortQuery = `sort={"price": -1}`;
         break;
-      case '낮은가격순':
-        sorted.sort((a, b) => a.price - b.price);
+      case 'minPrice':
+        sortQuery = `sort={"price": 1}`;
         break;
-      // 기타 케이스 추가 가능
     }
-    setSortedProducts(sorted);
+
+    const sortFetchProducts = async () => {
+      try {
+        const response = await api.getProductList(sortQuery);
+        setSortedProducts(response.data.item);
+      } catch (error) {
+        console.log('데이터를 받아오지 못했습니다.', error);
+      }
+    };
+    sortFetchProducts();
   }, [products, currentSortOrder]);
 
   return [sortedProducts, setCurrentSortOrder];

--- a/src/pages/product/SearchPage.tsx
+++ b/src/pages/product/SearchPage.tsx
@@ -20,7 +20,7 @@ import {
   PRICE_RANGE,
   SHIPPING_FEE,
 } from '../../constants';
-// import { useFetchProducts } from '../../hooks/useFetchProducts';
+// import { useFetchProducts } from '../../hooks/useFetchProducts';   // TODO : reactQuery 작업
 import { ProductGrid } from '../../components/search/ProductGrid';
 import MobileNavBar from '../../components/navbar/MobileNavBar';
 
@@ -48,6 +48,8 @@ export function SearchPage() {
   function toggleSidebar() {
     setIsSidebarOpen(!isSidebarOpen);
   }
+
+  // TODO : reactQuery 작업
   // const productListQuery = {};
   // const { data, error, isLoading } = useFetchProducts(productListQuery);
 
@@ -88,6 +90,7 @@ export function SearchPage() {
     setSelectedShippingFee('전체');
   };
 
+  // TODO : reactQuery 작업
   // if (error) {
   //   console.error('Error fetching products:', error);
   //   return <div>Error fetching products</div>;

--- a/src/pages/product/SearchPage.tsx
+++ b/src/pages/product/SearchPage.tsx
@@ -20,7 +20,7 @@ import {
   PRICE_RANGE,
   SHIPPING_FEE,
 } from '../../constants';
-import { useFetchProducts } from '../../hooks/useFetchProducts';
+// import { useFetchProducts } from '../../hooks/useFetchProducts';
 import { ProductGrid } from '../../components/search/ProductGrid';
 import MobileNavBar from '../../components/navbar/MobileNavBar';
 
@@ -48,15 +48,15 @@ export function SearchPage() {
   function toggleSidebar() {
     setIsSidebarOpen(!isSidebarOpen);
   }
-  const productListQuery = {};
-  const { data, error, isLoading } = useFetchProducts(productListQuery);
+  // const productListQuery = {};
+  // const { data, error, isLoading } = useFetchProducts(productListQuery);
 
   useEffect(() => {
-    if (data) {
-      setSearchResult(Array.isArray(data.data.item) ? data.data.item : []);
+    if (sortedProducts) {
+      setSearchResult(Array.isArray(sortedProducts) ? sortedProducts : []);
       setIsDataFetched(true);
     }
-  }, [data, setSearchResult]);
+  }, [setSearchResult]);
 
   const handleDisplayChange = (value: number) => {
     setItemsPerPage(value);
@@ -88,10 +88,10 @@ export function SearchPage() {
     setSelectedShippingFee('전체');
   };
 
-  if (error) {
-    console.error('Error fetching products:', error);
-    return <div>Error fetching products</div>;
-  }
+  // if (error) {
+  //   console.error('Error fetching products:', error);
+  //   return <div>Error fetching products</div>;
+  // }
 
   // 사이드바 Grid: MUI Slide의 ref 문제로 인해 내부에서 관리
   const sidebarGrid = (
@@ -266,7 +266,7 @@ export function SearchPage() {
           </Slide>
           <Grid item xs={isSidebarOpen ? 9 : 12}>
             <ProductGrid
-              isLoading={isLoading}
+              // isLoading={isLoading}
               isDataFetched={isDataFetched}
               filteredProducts={filteredProducts}
               itemsPerPage={itemsPerPage}

--- a/src/pages/product/SearchPage.tsx
+++ b/src/pages/product/SearchPage.tsx
@@ -28,7 +28,7 @@ export function SearchPage() {
   const { searchResult, setSearchResult } = useSearchStore();
   const [sortedProducts, setCurrentSortOrder] = useSort(
     searchResult,
-    '최신순',
+    'latest',
   ) as any;
   const [itemsPerPage, setItemsPerPage] = useState(6);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -149,6 +149,8 @@ export interface IProductListQuery {
   sort?: string;
   page?: number;
   limit?: number;
+  createdAt?: number;
+  price?: number;
 }
 
 export interface IBookmarkItem {


### PR DESCRIPTION
## 🧾 관련 이슈
close : #123 


## 🔎 구현한 내용
- 정렬 기능 API 적용


## 📸 스크린샷(선택사항)

![111](https://github.com/PhoenixFE/orum-market-front/assets/104605709/c3987a97-3fce-4276-a053-738caff1b118)
![2](https://github.com/PhoenixFE/orum-market-front/assets/104605709/1f777062-31da-4097-8c0c-19ac17756d65)



## 🙌 리뷰어에게
- useSort훅 활용하여 정렬 API 통신으로 변경했습니다. 
- 메인과 대시보드에서 통신하는 API가 달라서 switch문으로 분기처리 진행했습니다.
- 대시보드에서 ProductManager.tsx 부분은 현재 소영님이 다른 기능 구현중에 있으셔서 SellerOrderManager.tsx 부분만 먼저 적용했습니다.
- 내 주문 내역의 경우 날짜별 조회 방식으로 다르게 구현하고자 새로 이슈 파서 작업하려고 합니다.
- reactQuery 적용도 한번에 진행하려 합니다. (ProductGrid.tsx의 주석 처리 부분 사용 예정)
- 다음은 필터 API 연결 진행하겠습니다!

